### PR TITLE
Update shimmer references for KnickKnackLabs org transfer

### DIFF
--- a/.github/workflows/agent-run.yml
+++ b/.github/workflows/agent-run.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Checkout shimmer
         uses: actions/checkout@v4
         with:
-          repository: ricon-family/shimmer
+          repository: KnickKnackLabs/shimmer
           token: ${{ secrets.AGENT_GITHUB_PAT }}
           path: shimmer
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ Agent identities live in `agents/`. When dispatched, your identity comes from he
 
 ## History
 
-Named by democratic vote (issue ricon-family/shimmer#467). All 8 agents participated:
+Named by democratic vote (issue KnickKnackLabs/shimmer#467). All 8 agents participated:
 - fold: 22 points (winner)
 - hearth: 19 points
 - hollow: 4 points
@@ -52,7 +52,7 @@ Named by democratic vote (issue ricon-family/shimmer#467). All 8 agents particip
 
 ## Shimmer
 
-[shimmer](https://github.com/ricon-family/shimmer) is our tooling infrastructure. It provides:
+[shimmer](https://github.com/KnickKnackLabs/shimmer) is our tooling infrastructure. It provides:
 - Agent workflow orchestration
 - Common tasks (email, matrix, GitHub operations, etc.)
 - Job scheduling and dispatch

--- a/README.md
+++ b/README.md
@@ -30,6 +30,6 @@ fold welcome  # Verify setup
 
 ## Development
 
-This project uses [shimmer](https://github.com/ricon-family/shimmer) for agent workflow orchestration and tooling.
+This project uses [shimmer](https://github.com/KnickKnackLabs/shimmer) for agent workflow orchestration and tooling.
 
 Agents wake up in fold (home) and are dispatched to work on projects using their available resources.

--- a/workflows.yaml
+++ b/workflows.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/ricon-family/shimmer/main/workflows.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/KnickKnackLabs/shimmer/main/workflows.schema.json
 #
 # Agent workflow schedules for fold.
 # Run `shimmer workflows:generate` to regenerate workflow files.
@@ -21,5 +21,5 @@ workflows:
 #     agent: quick
 #     schedule: "0 */4 * * *"
 #     message: |
-#       Clone ricon-family/shimmer to your workspace.
+#       Clone KnickKnackLabs/shimmer to your workspace.
 #       Read .jobs/probe.txt and execute those instructions.


### PR DESCRIPTION
## Summary

- Replace all `ricon-family/shimmer` references with `KnickKnackLabs/shimmer` across the repository
- Preparation for the shimmer repository transferring from the `ricon-family` org to `KnickKnackLabs`
- Updated references in `CLAUDE.md`, `workflows.yaml`, `README.md`, and `.github/workflows/agent-run.yml` (6 occurrences total)

## Test plan

- [ ] Verify `grep -r "ricon-family/shimmer" .` returns zero results (confirmed locally)
- [ ] Confirm workflow schema URL resolves after org transfer completes
- [ ] Confirm `agent-run.yml` repository dispatch targets the correct org

🤖 Generated with [Claude Code](https://claude.com/claude-code)