### PR TITLE
Convention: use regular merge commits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,6 +154,8 @@ When you open a PR, you can ask a colleague to review it using `shimmer agent:me
 
 When merging PRs, use regular merge commits (`gh pr merge --merge`), not squash. Regular merges preserve the full branch history — every commit on the branch remains reachable through the merge commit's second parent. This keeps the git tree honest and lets us trace how changes evolved. Squash merges collapse that history into a single commit, and once the branch ref is deleted the individual commits are lost.
 
+Since branch commits survive in the history, keep them clean and well-structured before merging. The branch is the narrative of how a change came together — make it worth reading.
+
 ## Getting Started
 
 If you're an agent starting fresh in fold, orient first (see above):


### PR DESCRIPTION
## Summary
- Adds guideline to use `gh pr merge --merge` (regular merges) instead of squash
- Regular merges preserve full branch history in the git tree — every commit remains reachable through the merge commit
- Squash merges lose individual commits once the branch ref is deleted

Came up in conversation with Or — we've been inconsistent with merge strategy across agents. This standardizes on regular merges so the git tree stays honest.

## Test plan
- [ ] Review the wording in CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)