### PR TITLE
feat: add codebase linting + setup task

### DIFF
--- a/.mise/tasks/setup
+++ b/.mise/tasks/setup
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+#MISE description="Set up dev environment (hooks, tools)"
+set -euo pipefail
+
+echo "Setting up $(basename "$MISE_CONFIG_ROOT")..."
+
+if command -v codebase &>/dev/null; then
+  cd "$MISE_CONFIG_ROOT" && codebase pre-commit
+else
+  echo "WARN: codebase not found — run 'mise install' first" >&2
+fi
+
+echo "Done."

--- a/mise.toml
+++ b/mise.toml
@@ -10,16 +10,13 @@ shiv = "https://github.com/KnickKnackLabs/vfox-shiv"
 "ubi:pimalaya/himalaya" = "1.1.0" # Email CLI for agents
 usage = "1"                       # CLI arg parsing for tasks
 yq = "4.50.1"                     # YAML processing
-"shiv:shiv" = "latest"
 "shiv:shimmer" = "latest"
 "shiv:sessions" = "0.3.0"
 "shiv:modules" = "0.7.0"
 "shiv:notes" = "0.8.0"
-"shiv:rudi" = "0.5.1"
 "shiv:secrets" = "0.1.0"
-"shiv:shell" = "0.1.0"
 "shiv:emails" = "0.3.0"
-"shiv:codebase" = "0.1.0"                 # Codebase linting + migrations
+"shiv:codebase" = "0.1.0"
 
 [_.codebase]
 lint = ["mise-settings", "gum-table"]

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,7 @@
 [settings]
 experimental = true
+quiet = true
+task_output = "interleave"
 
 [plugins]
 shiv = "https://github.com/KnickKnackLabs/vfox-shiv"
@@ -17,3 +19,10 @@ yq = "4.50.1"                     # YAML processing
 "shiv:secrets" = "0.1.0"
 "shiv:shell" = "0.1.0"
 "shiv:emails" = "0.3.0"
+"shiv:codebase" = "0.1.0"                 # Codebase linting + migrations
+
+[_.codebase]
+lint = ["mise-settings", "gum-table"]
+
+[_.codebase.scope]
+gum-table = ".mise/tasks"


### PR DESCRIPTION
Mirrors den#13 — adds codebase linting to fold.

- `shiv:codebase` as tool dependency
- `[_.codebase]` lint config with `mise-settings` + `gum-table` (scoped to `.mise/tasks`)
- `quiet = true` and `task_output = "interleave"` in settings
- `setup` task installs pre-commit hook

After merging: `mise install && mise run setup`