### PR TITLE
fix: run agents from the checked out workspace

### DIFF
--- a/.github/workflows/agent-run.yml
+++ b/.github/workflows/agent-run.yml
@@ -188,7 +188,6 @@ jobs:
 
       - name: Run agent
         env:
-          AGENT_HOME: $GITHUB_WORKSPACE
           AGENT: ${{ inputs.agent }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           BROWSER_GITHUB_COM_PASSWORD: ${{ secrets.AGENT_GITHUB_PASSWORD }}
@@ -199,6 +198,9 @@ jobs:
           RUN_TIMEOUT: 900
         run: |
           echo "### AGENT SESSION START ###"
+
+          cd "$GITHUB_WORKSPACE"
+          export CALLER_PWD="$GITHUB_WORKSPACE"
 
           # shimmer as sets identity env vars (AGENT_IDENTITY, GIT_AUTHOR_*, GH_TOKEN, etc.)
           # shimmer agent --headless delegates to sessions run for execution


### PR DESCRIPTION
## Summary
- regenerate fold's reusable workflow so the run step executes from `$GITHUB_WORKSPACE`
- export `CALLER_PWD=$GITHUB_WORKSPACE` before `shimmer as` / `shimmer agent`
- fixes CI wake-ups that were resolving the home repo from `/home/runner/fold` instead of the checked-out repo root

## Notes
- companion to the corresponding shimmer template update

## Testing
- `PROJECT_DIR="$PWD" mise -C ~/agents/quick/shimmer run workflows:generate --check`
- `ruby -e 'require "yaml"; YAML.load_file("workflows.yaml"); Dir[".github/workflows/*.yml"].each { |f| YAML.load_file(f) }; puts "ok"'`\n