### PR TITLE
test: strengthen exact invitation acceptance mock

### DIFF
--- a/test/github_repo_invitations.bats
+++ b/test/github_repo_invitations.bats
@@ -42,6 +42,8 @@ setup() {
   run fold_task github:repo:accept-invite rikonor/ideas --as rho --yes
   [ "$status" -eq 0 ]
   grep -q 'GH_TOKEN=token-rho ARGS=api -X PATCH /user/repository_invitations/321' "$MOCK_GH_LOG"
+  ! grep -q 'repository_invitations/322' "$MOCK_GH_LOG"
+  ! grep -q 'repository_invitations/323' "$MOCK_GH_LOG"
   [[ "$output" == *"rho"*"rho-ricon"*"accepted"*"WRITE"* ]]
 }
 

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -57,10 +57,30 @@ if [ "${1:-}" = "api" ] && [[ "${2:-}" == /repos/rikonor/ideas/collaborators/*/p
 fi
 
 if [ "${1:-}" = "api" ] && [ "${2:-}" = "/user/repository_invitations" ]; then
+  jq_filter=""
+  for ((i = 3; i <= $#; i++)); do
+    arg="${!i}"
+    if [ "$arg" = "--jq" ]; then
+      next=$((i + 1))
+      jq_filter="${!next:-}"
+      break
+    fi
+  done
+
   case "${GH_TOKEN:-ambient}" in
-    token-rho) echo "321" ;;
+    token-rho)
+      if [ -z "$jq_filter" ]; then
+        printf '%s\n' 321 322 323
+      elif [[ "$jq_filter" == *'"rikonor"'* && "$jq_filter" == *'"ideas"'* ]]; then
+        echo "321"
+      fi
+      ;;
     token-quick) : ;;
-    *) echo "999" ;;
+    *)
+      if [[ "$jq_filter" == *'"rikonor"'* && "$jq_filter" == *'"ideas"'* ]]; then
+        echo "999"
+      fi
+      ;;
   esac
   exit 0
 fi


### PR DESCRIPTION
Fix-it for ricon-family/fold#76.

This strengthens the invitation acceptance mock so the test harness catches a regression where `accept-invite` accepts every pending repository invitation instead of only the requested `OWNER/REPO`.

Validation: `mise run test`.
