### PR TITLE
fix: handle unterminated shiv rollout plan rows

### DIFF
--- a/.mise/tasks/shiv/rollout
+++ b/.mise/tasks/shiv/rollout
@@ -317,7 +317,7 @@ printf 'commit:  %s\n' "$COMMIT_MESSAGE"
 printf 'mode:    %s\n' "$( [ "$YES" = "true" ] && echo mutate || echo dry-run )"
 printf 'missing: %s\n\n' "$( [ "$ADD_MISSING" = "true" ] && echo add || echo skip )"
 
-while IFS=$'\t' read -r repo push_agent extra; do
+while IFS=$'\t' read -r repo push_agent extra || [ -n "${repo:-}" ]; do
   [ -z "${repo//[[:space:]]/}" ] && continue
   [[ "$repo" == \#* ]] && continue
   if [ -n "${extra:-}" ]; then

--- a/test/shiv_rollout.bats
+++ b/test/shiv_rollout.bats
@@ -146,6 +146,23 @@ EOF
   [ "$author" = "k7r2 <k7r2@ricon.family>" ]
 }
 
+@test "shiv:rollout processes a final plan row without trailing newline" {
+  create_remote_repo "baby-joel/home" '[tools]
+"shiv:emails" = "0.5"
+'
+  printf 'baby-joel/home\tbaby-joel' > "$BATS_TEST_TMPDIR/plan.tsv"
+
+  run fold_task shiv:rollout emails 0.6 \
+    --plan "$BATS_TEST_TMPDIR/plan.tsv" \
+    --branch rollout/emails-0.6 \
+    --work-dir "$BATS_TEST_TMPDIR/clones" \
+    --no-gpg-sign
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"repo: baby-joel/home"* ]]
+  [[ "$output" == *"dependency: updated"* ]]
+}
+
 @test "shiv:rollout skips missing pins unless add-missing is explicit" {
   create_remote_repo "zeke/home" '[settings]
 quiet = true


### PR DESCRIPTION
Fix-it for ricon-family/fold#78.

The rollout task's plan loop skipped a valid final row if the TSV file did not end with a newline. This makes the loop process an unterminated final row and adds a regression test.

Validation:
- `bash -n .mise/tasks/shiv/rollout test/shiv_rollout.bats test/test_helper.bash`
- `mise exec shellcheck@0.11.0 -- shellcheck .mise/tasks/shiv/rollout test/shiv_rollout.bats test/test_helper.bash`
- `mise run test shiv_rollout --print-output-on-failure`
