### PR TITLE
fix: silence shiv rollout awk regex warning

### DIFF
--- a/.mise/tasks/shiv/rollout
+++ b/.mise/tasks/shiv/rollout
@@ -199,7 +199,7 @@ update_mise_toml() {
           exit 0
         }
 
-        key_re = "^[[:space:]]*\\\"" key "\\\"[[:space:]]*="
+        key_re = "^[[:space:]]*\"" key "\"[[:space:]]*="
         for (i = tools_start + 1; i <= tools_end; i++) {
           if (lines[i] ~ key_re) {
             found = 1

--- a/test/shiv_rollout.bats
+++ b/test/shiv_rollout.bats
@@ -106,6 +106,7 @@ quiet = true
 
   [ "$status" -eq 0 ]
   [[ "$output" == *"dependency: updated"* ]]
+  [[ "$output" != *"regexp escape sequence"* ]]
   [[ "$output" == *"dry-run: would commit and push rollout/emails-0.6"* ]]
   grep -q 'GH_TOKEN=token-baby-joel ARGS=.* clone .*baby-joel/home.git' "$MOCK_GIT_LOG"
   run git --git-dir="$MOCK_GIT_REMOTE_ROOT/baby-joel/home.git" show-ref --verify refs/heads/rollout/emails-0.6


### PR DESCRIPTION
Fix-it for #78.

While adversarially smoke-testing the new rollout task against a real fresh clone, mawk printed:

```text
awk: cmd. line:34: warning: regexp escape sequence `\"' is not a known regexp operator
```

The task still updated the file, but every real rollout dry-run was polluted by the warning. This removes the unnecessary regex backslash before the TOML key quotes and adds a regression assertion.

Validation:

- `bash -n .mise/tasks/shiv/rollout test/shiv_rollout.bats`
- `mise exec shellcheck@0.11.0 -- shellcheck .mise/tasks/shiv/rollout test/shiv_rollout.bats`
- `mise run test shiv_rollout --print-output-on-failure`
- Real dry-run: `mise run shiv:rollout emails 0.6 --repo ricon-family/fold --work-dir "$tmp" --no-gpg-sign --add-missing`
