### PR TITLE
fix: update shiv rollout pins with tab whitespace

### DIFF
--- a/.mise/tasks/shiv/rollout
+++ b/.mise/tasks/shiv/rollout
@@ -204,7 +204,7 @@ update_mise_toml() {
           if (lines[i] ~ key_re) {
             found = 1
             old = lines[i]
-            sub(/= *"[^"]*"/, "= \"" target_version "\"", lines[i])
+            sub(/=[[:space:]]*"[^"]*"/, "= \"" target_version "\"", lines[i])
             if (lines[i] != old) changed = 1
           }
         }

--- a/test/shiv_rollout.bats
+++ b/test/shiv_rollout.bats
@@ -141,6 +141,23 @@ jq = "1.8.1"
   [ "$author" = "k7r2 <k7r2@ricon.family>" ]
 }
 
+@test "shiv:rollout updates pins with tab-separated TOML whitespace" {
+  create_remote_repo "baby-joel/home" '[tools]
+"shiv:emails"	=	"0.5"
+'
+
+  run fold_task shiv:rollout emails 0.6 \
+    --repo baby-joel/home:baby-joel \
+    --branch rollout/emails-0.6 \
+    --work-dir "$BATS_TEST_TMPDIR/clones" \
+    --no-gpg-sign
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"dependency: updated"* ]]
+  [[ "$output" == *'-"shiv:emails"	=	"0.5"'* ]]
+  [[ "$output" == *'+"shiv:emails"	= "0.6"'* ]]
+}
+
 @test "shiv:rollout processes final plan row without trailing newline" {
   create_remote_repo "baby-joel/home" '[tools]
 "shiv:emails" = "0.5"


### PR DESCRIPTION
Fix-it for #78.

`shiv:rollout` currently finds a valid TOML line like:

```toml
"shiv:emails"	=	"0.5"
```

but its replacement regex only accepts literal spaces after `=`, so it reports `dependency: unchanged` and leaves the old pin in place. TOML permits tabs as whitespace, and the surrounding matcher already uses `[[:space:]]`.

This changes the replacement regex to accept POSIX whitespace and adds a regression.

Validation:

- `bash -n .mise/tasks/shiv/rollout test/shiv_rollout.bats`
- `mise run test shiv_rollout --print-output-on-failure`
