### PR TITLE
fix: match shiv rollout package keys literally

### DIFF
--- a/.mise/tasks/shiv/rollout
+++ b/.mise/tasks/shiv/rollout
@@ -199,7 +199,9 @@ update_mise_toml() {
           exit 0
         }
 
-        key_re = "^[[:space:]]*\"" key "\"[[:space:]]*="
+        key_re_key = key
+        gsub(/[][\\.^$*+?(){}|]/, "\\\\&", key_re_key)
+        key_re = "^[[:space:]]*\"" key_re_key "\"[[:space:]]*="
         for (i = tools_start + 1; i <= tools_end; i++) {
           if (lines[i] ~ key_re) {
             found = 1

--- a/test/shiv_rollout.bats
+++ b/test/shiv_rollout.bats
@@ -172,3 +172,19 @@ quiet = true
   run git --git-dir="$MOCK_GIT_REMOTE_ROOT/zeke/home.git" show-ref --verify refs/heads/rollout/emails-0.6
   [ "$status" -ne 0 ]
 }
+
+@test "shiv:rollout treats package names as literal TOML keys" {
+  create_remote_repo "baby-joel/home" '[tools]
+"shiv:fooXbar" = "0.5"
+'
+
+  run fold_task shiv:rollout foo.bar 1.0 \
+    --repo baby-joel/home \
+    --branch rollout/foo-bar-1.0 \
+    --work-dir "$BATS_TEST_TMPDIR/clones" \
+    --no-gpg-sign
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"dependency: missing"* ]]
+  [[ "$(cat "$BATS_TEST_TMPDIR/clones/baby-joel__home/mise.toml")" == *'"shiv:fooXbar" = "0.5"'* ]]
+}


### PR DESCRIPTION
Fix-it for #78.

The rollout task built an AWK regexp from the requested shiv package key without escaping regexp metacharacters. A package name containing `.` could therefore update a different key such as `shiv:fooXbar` when rolling out `foo.bar`.

Validation:
- `bash -n .mise/tasks/shiv/rollout test/shiv_rollout.bats`
- `mise exec shellcheck@0.11.0 -- shellcheck .mise/tasks/shiv/rollout test/shiv_rollout.bats`
- `mise run test shiv_rollout --print-output-on-failure`
