### PR TITLE
fix: broaden github token diagnostic redaction

### DIFF
--- a/.mise/tasks/github/token/create
+++ b/.mise/tasks/github/token/create
@@ -32,10 +32,36 @@ redact() {
   sed -E \
     -e 's/gh[pousr]_[A-Za-z0-9_]+/[REDACTED_GITHUB_TOKEN]/g' \
     -e 's/github_pat_[A-Za-z0-9_]+/[REDACTED_GITHUB_TOKEN]/g' \
+    -e 's/[A-Z2-7]{16,}/[REDACTED_BASE32]/g' \
+    -e 's/[a-z0-9]{5}-[a-z0-9]{5}/[REDACTED_RECOVERY_CODE]/gi' \
     -e 's/(Password: ).*/\1[REDACTED]/g' \
     -e 's/(GITHUB_PASSWORD=)[^[:space:]]+/\1[REDACTED]/g' \
     -e 's/(GITHUB_TOTP_CODE=)[^[:space:]]+/\1[REDACTED_TOTP_CODE]/g' \
+    -e 's/([Tt][Oo][Tt][Pp][^0-9]{0,32})[0-9]{6}/\1[REDACTED_TOTP_CODE]/g' \
+    -e 's/(^|[^0-9])[0-9]{6}([^0-9]|$)/\1[REDACTED_TOTP_CODE]\2/g' \
     -e 's/^TOKEN:.*/TOKEN:[REDACTED_GITHUB_TOKEN]/'
+}
+
+redact_literal() {
+  local literal="$1"
+  local replacement="$2"
+  awk -v literal="$literal" -v replacement="$replacement" '
+    literal == "" { print; next }
+    {
+      out = ""
+      rest = $0
+      while ((idx = index(rest, literal)) > 0) {
+        out = out substr(rest, 1, idx - 1) replacement
+        rest = substr(rest, idx + length(literal))
+      }
+      print out rest
+    }
+  '
+}
+
+redact_sensitive() {
+  local password="$1"
+  redact | redact_literal "$password" "[REDACTED_PASSWORD]"
 }
 
 validate_agent() {
@@ -220,7 +246,7 @@ while IFS= read -r agent; do
   if ! run_websites_create "$agent" "$username" "$password" "$stdout" "$stderr"; then
     printf '  ✗ token creation failed\n'
     printf '  sanitized diagnostics:\n'
-    redact <"$stderr" | sed 's/^/    /' | tail -100
+    redact_sensitive "$password" <"$stderr" | sed 's/^/    /' | tail -100
     exit 1
   fi
 
@@ -228,7 +254,7 @@ while IFS= read -r agent; do
   if [ -z "$new_token" ]; then
     printf '  ✗ token creation produced no token on stdout\n'
     printf '  sanitized diagnostics:\n'
-    redact <"$stderr" | sed 's/^/    /' | tail -100
+    redact_sensitive "$password" <"$stderr" | sed 's/^/    /' | tail -100
     exit 1
   fi
   printf '  ✓ created\n'

--- a/.mise/tasks/github/token/rotate
+++ b/.mise/tasks/github/token/rotate
@@ -32,9 +32,35 @@ redact() {
   sed -E \
     -e 's/gh[pousr]_[A-Za-z0-9_]+/[REDACTED_GITHUB_TOKEN]/g' \
     -e 's/github_pat_[A-Za-z0-9_]+/[REDACTED_GITHUB_TOKEN]/g' \
+    -e 's/[A-Z2-7]{16,}/[REDACTED_BASE32]/g' \
+    -e 's/[a-z0-9]{5}-[a-z0-9]{5}/[REDACTED_RECOVERY_CODE]/gi' \
     -e 's/(Password: ).*/\1[REDACTED]/g' \
     -e 's/(GITHUB_PASSWORD=)[^[:space:]]+/\1[REDACTED]/g' \
-    -e 's/(GITHUB_TOTP_CODE=)[^[:space:]]+/\1[REDACTED_TOTP_CODE]/g'
+    -e 's/(GITHUB_TOTP_CODE=)[^[:space:]]+/\1[REDACTED_TOTP_CODE]/g' \
+    -e 's/([Tt][Oo][Tt][Pp][^0-9]{0,32})[0-9]{6}/\1[REDACTED_TOTP_CODE]/g' \
+    -e 's/(^|[^0-9])[0-9]{6}([^0-9]|$)/\1[REDACTED_TOTP_CODE]\2/g'
+}
+
+redact_literal() {
+  local literal="$1"
+  local replacement="$2"
+  awk -v literal="$literal" -v replacement="$replacement" '
+    literal == "" { print; next }
+    {
+      out = ""
+      rest = $0
+      while ((idx = index(rest, literal)) > 0) {
+        out = out substr(rest, 1, idx - 1) replacement
+        rest = substr(rest, idx + length(literal))
+      }
+      print out rest
+    }
+  '
+}
+
+redact_sensitive() {
+  local password="$1"
+  redact | redact_literal "$password" "[REDACTED_PASSWORD]"
 }
 
 validate_agent() {
@@ -219,7 +245,7 @@ while IFS= read -r agent; do
   if ! run_websites_rotate "$agent" "$username" "$password" "$stdout" "$stderr"; then
     printf '  ✗ rotation failed\n'
     printf '  sanitized diagnostics:\n'
-    redact <"$stderr" | sed 's/^/    /' | tail -80
+    redact_sensitive "$password" <"$stderr" | sed 's/^/    /' | tail -80
     exit 1
   fi
 
@@ -227,7 +253,7 @@ while IFS= read -r agent; do
   if [ -z "$new_token" ]; then
     printf '  ✗ rotation produced no token on stdout\n'
     printf '  sanitized diagnostics:\n'
-    redact <"$stderr" | sed 's/^/    /' | tail -80
+    redact_sensitive "$password" <"$stderr" | sed 's/^/    /' | tail -80
     exit 1
   fi
   printf '  ✓ rotated\n'

--- a/test/github-token-totp-injection.bats
+++ b/test/github-token-totp-injection.bats
@@ -115,11 +115,44 @@ EOF
   [ ! -e "$BATS_TEST_TMPDIR/shimmer-log" ]
 }
 
-@test "github:token:rotate redacts TOTP codes from browser diagnostics" {
+@test "github:token:create redacts credential material from browser diagnostics" {
   cat > "$TMPBIN/websites" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 echo "diagnostic GITHUB_TOTP_CODE=${GITHUB_TOTP_CODE:-unset}" >&2
+echo "diagnostic bare totp ${GITHUB_TOTP_CODE:-unset}" >&2
+echo "diagnostic password ${GITHUB_PASSWORD:-unset}" >&2
+echo "diagnostic seed JBSWY3DPEHPK3PXP" >&2
+echo "diagnostic recovery a1b2c-3d4e5" >&2
+exit 42
+EOF
+  chmod +x "$TMPBIN/websites"
+  write_fake_shimmer_and_gh
+
+  run fold_task github:token:create --yes --no-sync-ci c0da
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"GITHUB_TOTP_CODE=[REDACTED_TOTP_CODE]"* ]]
+  [[ "$output" == *"bare totp [REDACTED_TOTP_CODE]"* ]]
+  [[ "$output" == *"password [REDACTED_PASSWORD]"* ]]
+  [[ "$output" == *"[REDACTED_BASE32]"* ]]
+  [[ "$output" == *"[REDACTED_RECOVERY_CODE]"* ]]
+  [[ "$output" != *"GITHUB_TOTP_CODE=123456"* ]]
+  [[ "$output" != *"bare totp 123456"* ]]
+  [[ "$output" != *"password-for-c0da"* ]]
+  [[ "$output" != *"JBSWY3DPEHPK3PXP"* ]]
+  [[ "$output" != *"a1b2c-3d4e5"* ]]
+}
+
+@test "github:token:rotate redacts credential material from browser diagnostics" {
+  cat > "$TMPBIN/websites" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "diagnostic GITHUB_TOTP_CODE=${GITHUB_TOTP_CODE:-unset}" >&2
+echo "diagnostic bare totp ${GITHUB_TOTP_CODE:-unset}" >&2
+echo "diagnostic password ${GITHUB_PASSWORD:-unset}" >&2
+echo "diagnostic seed JBSWY3DPEHPK3PXP" >&2
+echo "diagnostic recovery a1b2c-3d4e5" >&2
 exit 42
 EOF
   chmod +x "$TMPBIN/websites"
@@ -129,5 +162,13 @@ EOF
 
   [ "$status" -ne 0 ]
   [[ "$output" == *"GITHUB_TOTP_CODE=[REDACTED_TOTP_CODE]"* ]]
+  [[ "$output" == *"bare totp [REDACTED_TOTP_CODE]"* ]]
+  [[ "$output" == *"password [REDACTED_PASSWORD]"* ]]
+  [[ "$output" == *"[REDACTED_BASE32]"* ]]
+  [[ "$output" == *"[REDACTED_RECOVERY_CODE]"* ]]
   [[ "$output" != *"GITHUB_TOTP_CODE=123456"* ]]
+  [[ "$output" != *"bare totp 123456"* ]]
+  [[ "$output" != *"password-for-c0da"* ]]
+  [[ "$output" != *"JBSWY3DPEHPK3PXP"* ]]
+  [[ "$output" != *"a1b2c-3d4e5"* ]]
 }


### PR DESCRIPTION
Fix-it for #83.

This broadens token create/rotate diagnostic redaction beyond `GITHUB_TOTP_CODE=...` assignments so browser diagnostics cannot leak:

- bare six-digit TOTP codes (`totp 123456`)
- Base32 TOTP seeds
- GitHub recovery-code shaped values
- the exact in-memory GitHub password value

Validation:

- `bash -n .mise/tasks/github/token/create .mise/tasks/github/token/rotate`
- `mise run test github-token-totp-injection` (6/6 BATS + codebase lint + welcome smoke)
- `git diff --check`
- `mise run git:pre-commit` WARN only: no staged changes after commit; no unstaged tracked changes; notes clean after `notes deobfuscate --force`

Note: `git pre-commit` was not installed as a git subcommand in this checkout, so I used the repo task `mise run git:pre-commit` after discovering it with `mise tasks ls`.
