### PR TITLE
fix: check notes changes in homes preflight

### DIFF
--- a/.mise/tasks/homes/preflight
+++ b/.mise/tasks/homes/preflight
@@ -148,7 +148,7 @@ check_repo() {
 }
 
 check_notes() {
-  local tracked_readable
+  local notes_changes tracked_readable
 
   if [ -d "$HOME_PATH/notes" ]; then
     record ok "notes dir" "notes/ present"
@@ -158,6 +158,19 @@ check_notes() {
 
   if [ -f "$HOME_PATH/notes/.manifest" ]; then
     record ok "notes manifest" "notes/.manifest present"
+    if ! command -v notes >/dev/null 2>&1; then
+      record warn "notes changes" "notes tool unavailable; cannot check readable note changes"
+    elif notes_changes=$(cd "$HOME_PATH" && notes changes --summary 2>&1); then
+      if [ "$notes_changes" = "No changes." ]; then
+        record ok "notes changes" "clean"
+      else
+        record fail "notes changes" "readable note changes pending; use notes stage/commit before bootstrap"
+        printf '%s\n' "$notes_changes" | sed 's/^/       /'
+      fi
+    else
+      record fail "notes changes" "could not inspect notes workflow state"
+      printf '%s\n' "$notes_changes" | sed 's/^/       /'
+    fi
   else
     record warn "notes manifest" "missing; run homes:setup-notes"
   fi

--- a/test/homes_preflight.bats
+++ b/test/homes_preflight.bats
@@ -111,6 +111,20 @@ SH
   [[ "$output" == *"overall: fail"* ]]
 }
 
+@test "homes:preflight fails when ignored readable note changes are pending" {
+  home="$BATS_TEST_TMPDIR/home"
+  create_clean_home "$home"
+  printf 'notes/*.md\n' >> "$home/.git/info/exclude"
+  printf '# Status\n' > "$home/notes/status.md"
+
+  run fold_task homes:preflight test-agent --home "$home"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"ok     worktree"*"clean"* ]]
+  [[ "$output" == *"fail   notes changes"*"readable note changes pending"* ]]
+  [[ "$output" == *"new:"*"status.md"* ]]
+}
+
 @test "homes:preflight fails when readable note filenames are tracked" {
   home="$BATS_TEST_TMPDIR/home"
   create_clean_home "$home"


### PR DESCRIPTION
Fix-it PR for fold#85.

This adds a `notes changes --summary` preflight check when `notes/.manifest` exists, so a notes-managed home with ignored readable note edits cannot pass as "clean" just because `git status --porcelain` is empty.

Validation:

- `mise run test homes_preflight`
- `mise run test`
- `mise run git:pre-push` (warned only that this new fix-it branch initially had no upstream and that inherited PR commits include unavailable/unknown signatures)
