### PR TITLE
fix: block publication with pending note changes

### DIFF
--- a/.mise/lib/homes.sh
+++ b/.mise/lib/homes.sh
@@ -12,7 +12,8 @@ source "$HOMES_LIB_DIR/common.sh"
 
 GIT_BIN="${GIT:-git}"
 GPG_BIN="${GPG:-gpg}"
-export GIT_BIN GPG_BIN
+NOTES_BIN="${NOTES:-notes}"
+export GIT_BIN GPG_BIN NOTES_BIN
 
 homes_agent_email() {
   printf '%s@ricon.family\n' "$1"
@@ -89,6 +90,29 @@ homes_fail_on_tracked_readable_notes() {
   fi
 }
 
+homes_fail_on_pending_note_changes() {
+  local home_path="$1" notes_changes
+
+  [ -f "$home_path/notes/.manifest" ] || return 0
+
+  if ! command -v "$NOTES_BIN" >/dev/null 2>&1; then
+    echo "ERROR: notes/.manifest exists but notes tool is unavailable" >&2
+    exit 1
+  fi
+
+  if ! notes_changes=$(cd "$home_path" && "$NOTES_BIN" changes --summary 2>&1); then
+    echo "ERROR: could not inspect notes workflow state before publishing" >&2
+    printf '%s\n' "$notes_changes" >&2
+    exit 1
+  fi
+
+  if [ "$notes_changes" != "No changes." ]; then
+    echo "ERROR: readable note changes are pending; use notes stage/commit before publishing" >&2
+    printf '%s\n' "$notes_changes" | sed 's/^/  /' >&2
+    exit 1
+  fi
+}
+
 homes_blob_hex10() {
   local repo="$1" refpath="$2" tmp hex
   tmp=$(mktemp)
@@ -138,6 +162,7 @@ homes_assert_publishable_tree() {
   homes_require_head "$home_path"
   homes_require_clean_worktree "$home_path"
   homes_fail_on_tracked_readable_notes "$home_path"
+  homes_fail_on_pending_note_changes "$home_path"
 
   homes_assert_gitcrypt_blob "$home_path" 'HEAD:notes/.manifest'
   homes_assert_gitcrypt_blob "$home_path" 'HEAD:.modules/manifest'

--- a/.mise/tasks/homes/commit-local
+++ b/.mise/tasks/homes/commit-local
@@ -18,7 +18,6 @@ HOME_PATH=$(homes_resolve_home "$AGENT" "${usage_home:-}")
 YES="${usage_yes:-false}"
 MESSAGE="${usage_message:-}"
 NO_GPG_SIGN="${usage_no_gpg_sign:-false}"
-NOTES_BIN="${NOTES:-notes}"
 
 stage_bootstrap_surfaces() {
   local paths=() path notes_changes

--- a/test/homes_publication.bats
+++ b/test/homes_publication.bats
@@ -94,9 +94,32 @@ SH
   export GIT="$path"
 }
 
-write_mock_notes_with_pending_changes() {
+write_mock_notes_clean() {
   local path="$BATS_TEST_TMPDIR/notes"
   cat > "$path" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-}" in
+  stage|obfuscate)
+    exit 0
+    ;;
+  changes)
+    if [ "${2:-}" = "--summary" ]; then
+      printf 'No changes.\n'
+      exit 0
+    fi
+    ;;
+esac
+echo "unexpected notes command: $*" >&2
+exit 2
+SH
+  chmod +x "$path"
+  export NOTES="$path"
+}
+
+write_mock_notes_with_pending_changes() {
+  write_mock_notes_clean
+  cat > "$NOTES" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
 case "${1:-}" in
@@ -113,8 +136,6 @@ esac
 echo "unexpected notes command: $*" >&2
 exit 2
 SH
-  chmod +x "$path"
-  export NOTES="$path"
 }
 
 @test "homes:publish-fresh dry-run verifies encrypted blobs without pushing" {
@@ -122,6 +143,7 @@ SH
   remote="$BATS_TEST_TMPDIR/home.git"
   create_publishable_home "$home"
   create_bare_remote "$remote"
+  write_mock_notes_clean
 
   run fold_task homes:publish-fresh test-agent \
     --home "$home" \
@@ -138,6 +160,7 @@ SH
 @test "homes:publish-fresh dry-run fails when the remote is unreachable" {
   home="$BATS_TEST_TMPDIR/home"
   create_publishable_home "$home"
+  write_mock_notes_clean
 
   run fold_task homes:publish-fresh test-agent \
     --home "$home" \
@@ -154,6 +177,7 @@ SH
   create_publishable_home "$home"
   create_bare_remote "$remote"
   write_archive_guard_git
+  write_mock_notes_clean
 
   run fold_task homes:publish-fresh test-agent \
     --home "$home" \
@@ -171,11 +195,31 @@ SH
   assert_remote_blob_matches_source "$home" "$remote" .modules/manifest
 }
 
+@test "homes:publish-fresh rejects pending readable note changes" {
+  home="$BATS_TEST_TMPDIR/home"
+  remote="$BATS_TEST_TMPDIR/home.git"
+  create_publishable_home "$home"
+  create_bare_remote "$remote"
+  write_mock_notes_with_pending_changes
+
+  run fold_task homes:publish-fresh test-agent \
+    --home "$home" \
+    --remote-url "$remote" \
+    --no-gpg-sign \
+    --yes
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"readable note changes are pending"* ]]
+  run git --git-dir="$remote" show-ref --verify refs/heads/main
+  [ "$status" -ne 0 ]
+}
+
 @test "homes:publish-fresh rejects plaintext publication blobs" {
   home="$BATS_TEST_TMPDIR/home"
   remote="$BATS_TEST_TMPDIR/home.git"
   create_plaintext_home "$home"
   create_bare_remote "$remote"
+  write_mock_notes_clean
 
   run fold_task homes:publish-fresh test-agent \
     --home "$home" \


### PR DESCRIPTION
Fix-it for fold#87 review.

Blocks `homes:publish-fresh` when `notes changes --summary` reports pending readable note edits, closing the ignored-readable-note gap that `git status --porcelain` cannot see in notes-managed homes.

Validation:
- `bash -n .mise/lib/homes.sh .mise/tasks/homes/adopt-remote .mise/tasks/homes/commit-local .mise/tasks/homes/publish-fresh .mise/tasks/homes/smoke`
- `mise run test homes_publication`
- `mise run test`
- `git diff --check 93c0514e0889409f211327dbe20f036a3510b05d..HEAD -- .mise test notes`
