### PR TITLE
fix: harden homes preflight checks

### DIFF
--- a/.mise/tasks/homes/preflight
+++ b/.mise/tasks/homes/preflight
@@ -45,7 +45,7 @@ secret_present() {
   LAST_SECRET_VALUE=""
 
   if ! command -v "$SECRETS_BIN" >/dev/null 2>&1; then
-    record warn "secret:$key" "secrets tool unavailable; cannot check"
+    record fail "secret:$key" "secrets tool unavailable; cannot check"
     return 1
   fi
 
@@ -73,7 +73,7 @@ check_gpg_key() {
   fi
 
   if ! command -v "$GPG_BIN" >/dev/null 2>&1; then
-    record warn "gpg secret key" "gpg tool unavailable; cannot check local keyring"
+    record fail "gpg secret key" "gpg tool unavailable; cannot check local keyring"
     return 0
   fi
 
@@ -141,6 +141,7 @@ check_repo() {
   fi
 
   if origin=$("$GIT_BIN" -C "$HOME_PATH" remote get-url origin 2>/dev/null); then
+    origin=$(printf '%s' "$origin" | redact_github_tokens)
     record info "origin" "$origin"
   else
     record info "origin" "not configured"
@@ -159,7 +160,7 @@ check_notes() {
   if [ -f "$HOME_PATH/notes/.manifest" ]; then
     record ok "notes manifest" "notes/.manifest present"
     if ! command -v notes >/dev/null 2>&1; then
-      record warn "notes changes" "notes tool unavailable; cannot check readable note changes"
+      record fail "notes changes" "notes tool unavailable; cannot check readable note changes"
     elif notes_changes=$(cd "$HOME_PATH" && notes changes --summary 2>&1); then
       if [ "$notes_changes" = "No changes." ]; then
         record ok "notes changes" "clean"

--- a/.mise/tasks/homes/preflight
+++ b/.mise/tasks/homes/preflight
@@ -14,6 +14,7 @@ AGENT="${usage_agent:?agent required}"
 HOME_PATH="${usage_home:-}"
 GIT_BIN="${GIT:-git}"
 GPG_BIN="${GPG:-gpg}"
+NOTES_BIN="${NOTES:-notes}"
 
 failures=0
 warnings=0
@@ -159,9 +160,9 @@ check_notes() {
 
   if [ -f "$HOME_PATH/notes/.manifest" ]; then
     record ok "notes manifest" "notes/.manifest present"
-    if ! command -v notes >/dev/null 2>&1; then
+    if ! command -v "$NOTES_BIN" >/dev/null 2>&1; then
       record fail "notes changes" "notes tool unavailable; cannot check readable note changes"
-    elif notes_changes=$(cd "$HOME_PATH" && notes changes --summary 2>&1); then
+    elif notes_changes=$(cd "$HOME_PATH" && "$NOTES_BIN" changes --summary 2>&1); then
       if [ "$notes_changes" = "No changes." ]; then
         record ok "notes changes" "clean"
       else

--- a/test/homes_preflight.bats
+++ b/test/homes_preflight.bats
@@ -126,6 +126,17 @@ SH
   [[ "$output" == *"fail   gpg secret key"*"gpg tool unavailable"* ]]
 }
 
+@test "homes:preflight fails closed when notes is unavailable for a notes-managed home" {
+  home="$BATS_TEST_TMPDIR/home"
+  create_clean_home "$home"
+  export NOTES="$TMPBIN/missing-notes"
+
+  run fold_task homes:preflight test-agent --home "$home"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"fail   notes changes"*"notes tool unavailable"* ]]
+}
+
 @test "homes:preflight fails when the home path is missing" {
   run fold_task homes:preflight test-agent --home "$BATS_TEST_TMPDIR/missing-home"
 

--- a/test/homes_preflight.bats
+++ b/test/homes_preflight.bats
@@ -75,6 +75,18 @@ SH
     commit -q -m "initial"
 }
 
+@test "homes:preflight redacts GitHub tokens embedded in origin URLs" {
+  home="$BATS_TEST_TMPDIR/home"
+  create_clean_home "$home"
+  git -C "$home" remote add origin "https://x-access-token:ghp_secretfixturetoken@github.com/test-agent/home.git"
+
+  run fold_task homes:preflight test-agent --home "$home"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"info   origin"*"[REDACTED_GITHUB_TOKEN]"* ]]
+  [[ "$output" != *"ghp_secretfixturetoken"* ]]
+}
+
 @test "homes:preflight passes a clean already-provisioned home" {
   home="$BATS_TEST_TMPDIR/home"
   create_clean_home "$home"
@@ -88,6 +100,30 @@ SH
   [[ "$output" == *"ok     secret:gpg-fingerprint"*"present"* ]]
   [[ "$output" == *"ok     gpg secret key"*"present for stored fingerprint"* ]]
   [[ "$output" == *"overall: pass"* ]]
+}
+
+@test "homes:preflight fails closed when the secrets tool is unavailable" {
+  home="$BATS_TEST_TMPDIR/home"
+  create_clean_home "$home"
+  export SECRETS="$TMPBIN/missing-secrets"
+
+  run fold_task homes:preflight test-agent --home "$home"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"fail   secret:gpg-fingerprint"*"secrets tool unavailable"* ]]
+  [[ "$output" == *"fail   secret:github-username"*"secrets tool unavailable"* ]]
+  [[ "$output" == *"fail   secret:github-pat"*"secrets tool unavailable"* ]]
+}
+
+@test "homes:preflight fails closed when gpg is unavailable" {
+  home="$BATS_TEST_TMPDIR/home"
+  create_clean_home "$home"
+  export GPG="$TMPBIN/missing-gpg"
+
+  run fold_task homes:preflight test-agent --home "$home"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"fail   gpg secret key"*"gpg tool unavailable"* ]]
 }
 
 @test "homes:preflight fails when the home path is missing" {


### PR DESCRIPTION
Fix-it for #85 adversarial review.

Changes:
- redact GitHub tokens embedded in home `origin` URLs before printing preflight output
- fail closed when `secrets`, `gpg`, or `notes` cannot perform checks that the task treats as safety boundaries
- add BATS coverage for origin-token redaction plus unavailable `secrets`/`gpg` failure modes

Validation:
- `mise run test homes_preflight`
- `mise run test`
