### PR TITLE
test: cover missing notes in homes preflight

### DIFF
--- a/.mise/tasks/homes/preflight
+++ b/.mise/tasks/homes/preflight
@@ -14,6 +14,7 @@ AGENT="${usage_agent:?agent required}"
 HOME_PATH="${usage_home:-}"
 GIT_BIN="${GIT:-git}"
 GPG_BIN="${GPG:-gpg}"
+NOTES_BIN="${NOTES:-notes}"
 
 failures=0
 warnings=0
@@ -159,9 +160,9 @@ check_notes() {
 
   if [ -f "$HOME_PATH/notes/.manifest" ]; then
     record ok "notes manifest" "notes/.manifest present"
-    if ! command -v notes >/dev/null 2>&1; then
+    if ! command -v "$NOTES_BIN" >/dev/null 2>&1; then
       record fail "notes changes" "notes tool unavailable; cannot check readable note changes"
-    elif notes_changes=$(cd "$HOME_PATH" && notes changes --summary 2>&1); then
+    elif notes_changes=$(cd "$HOME_PATH" && "$NOTES_BIN" changes --summary 2>&1); then
       if [ "$notes_changes" = "No changes." ]; then
         record ok "notes changes" "clean"
       else

--- a/test/homes_preflight.bats
+++ b/test/homes_preflight.bats
@@ -126,6 +126,17 @@ SH
   [[ "$output" == *"fail   gpg secret key"*"gpg tool unavailable"* ]]
 }
 
+@test "homes:preflight fails closed when notes is unavailable for a notes-managed home" {
+  home="$BATS_TEST_TMPDIR/home"
+  create_clean_home "$home"
+  export NOTES="$TMPBIN/missing-notes"
+
+  run fold_task homes:preflight test-agent --home "$home"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"fail   notes changes"*"notes tool unavailable"* ]]
+}
+
 @test "homes:preflight fails when the home path is missing" {
   run fold_task homes:preflight test-agent --home "$BATS_TEST_TMPDIR/missing-home"
 


### PR DESCRIPTION
## Summary

- Add `NOTES="${NOTES:-notes}"` injection support to `homes:preflight`, matching the existing `GIT`/`GPG`/`SECRETS` mock pattern.
- Add the missing regression for c0da's fail-closed `notes` path: a notes-managed home fails preflight when the notes tool is unavailable.

## Validation

- `bash -n .mise/tasks/homes/preflight`
- `mise run test homes_preflight`
- `mise run test`
- `mise run git:pre-commit .`
