### PR TITLE
homes: block publish with pending note changes

### DIFF
--- a/.mise/lib/homes.sh
+++ b/.mise/lib/homes.sh
@@ -12,7 +12,8 @@ source "$HOMES_LIB_DIR/common.sh"
 
 GIT_BIN="${GIT:-git}"
 GPG_BIN="${GPG:-gpg}"
-export GIT_BIN GPG_BIN
+NOTES_BIN="${NOTES:-notes}"
+export GIT_BIN GPG_BIN NOTES_BIN
 
 homes_agent_email() {
   printf '%s@ricon.family\n' "$1"
@@ -89,6 +90,29 @@ homes_fail_on_tracked_readable_notes() {
   fi
 }
 
+homes_require_no_pending_note_changes() {
+  local home_path="$1" notes_changes
+
+  [ -f "$home_path/notes/.manifest" ] || return 0
+
+  if ! command -v "$NOTES_BIN" >/dev/null 2>&1; then
+    echo "ERROR: notes/.manifest exists but notes tool is unavailable" >&2
+    exit 1
+  fi
+
+  if ! notes_changes=$(cd "$home_path" && "$NOTES_BIN" changes --summary 2>&1); then
+    echo "ERROR: could not inspect notes workflow state before publishing" >&2
+    printf '%s\n' "$notes_changes" >&2
+    exit 1
+  fi
+
+  if [ "$notes_changes" != "No changes." ]; then
+    echo "ERROR: note changes remain; resolve notes workflow before publishing" >&2
+    printf '%s\n' "$notes_changes" | sed 's/^/  /' >&2
+    exit 1
+  fi
+}
+
 homes_blob_hex10() {
   local repo="$1" refpath="$2" tmp hex
   tmp=$(mktemp)
@@ -137,6 +161,7 @@ homes_assert_publishable_tree() {
   homes_require_git_repo "$home_path"
   homes_require_head "$home_path"
   homes_require_clean_worktree "$home_path"
+  homes_require_no_pending_note_changes "$home_path"
   homes_fail_on_tracked_readable_notes "$home_path"
 
   homes_assert_gitcrypt_blob "$home_path" 'HEAD:notes/.manifest'

--- a/test/homes_publication.bats
+++ b/test/homes_publication.bats
@@ -94,6 +94,22 @@ SH
   export GIT="$path"
 }
 
+write_mock_notes_no_changes() {
+  local path="$BATS_TEST_TMPDIR/notes-clean"
+  cat > "$path" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "${1:-}" = "changes" ] && [ "${2:-}" = "--summary" ]; then
+  echo "No changes."
+  exit 0
+fi
+echo "unexpected notes command: $*" >&2
+exit 2
+SH
+  chmod +x "$path"
+  export NOTES="$path"
+}
+
 write_mock_notes_with_pending_changes() {
   local path="$BATS_TEST_TMPDIR/notes"
   cat > "$path" <<'SH'
@@ -122,6 +138,7 @@ SH
   remote="$BATS_TEST_TMPDIR/home.git"
   create_publishable_home "$home"
   create_bare_remote "$remote"
+  write_mock_notes_no_changes
 
   run fold_task homes:publish-fresh test-agent \
     --home "$home" \
@@ -138,6 +155,7 @@ SH
 @test "homes:publish-fresh dry-run fails when the remote is unreachable" {
   home="$BATS_TEST_TMPDIR/home"
   create_publishable_home "$home"
+  write_mock_notes_no_changes
 
   run fold_task homes:publish-fresh test-agent \
     --home "$home" \
@@ -153,6 +171,7 @@ SH
   remote="$BATS_TEST_TMPDIR/home.git"
   create_publishable_home "$home"
   create_bare_remote "$remote"
+  write_mock_notes_no_changes
   write_archive_guard_git
 
   run fold_task homes:publish-fresh test-agent \
@@ -176,6 +195,7 @@ SH
   remote="$BATS_TEST_TMPDIR/home.git"
   create_plaintext_home "$home"
   create_bare_remote "$remote"
+  write_mock_notes_no_changes
 
   run fold_task homes:publish-fresh test-agent \
     --home "$home" \
@@ -185,6 +205,29 @@ SH
 
   [ "$status" -eq 1 ]
   [[ "$output" == *"not a git-crypt blob"* ]]
+  run git --git-dir="$remote" show-ref --verify refs/heads/main
+  [ "$status" -ne 0 ]
+}
+
+
+@test "homes:publish-fresh rejects ignored readable note changes before publishing" {
+  home="$BATS_TEST_TMPDIR/home"
+  remote="$BATS_TEST_TMPDIR/home.git"
+  create_publishable_home "$home"
+  create_bare_remote "$remote"
+  printf 'notes/*.md\n' >> "$home/.git/info/exclude"
+  printf '# pending readable status\n' > "$home/notes/status.md"
+  write_mock_notes_with_pending_changes
+
+  run fold_task homes:publish-fresh test-agent \
+    --home "$home" \
+    --remote-url "$remote" \
+    --no-gpg-sign \
+    --yes
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"note changes remain"* ]]
+  [[ "$output" == *"modified:"*"status.md"* ]]
   run git --git-dir="$remote" show-ref --verify refs/heads/main
   [ "$status" -ne 0 ]
 }


### PR DESCRIPTION
Fix-it PR for #91.

`homes:publish-fresh` currently gates on `git status --porcelain`, tracked readable note filenames, and encrypted HEAD blobs, but it does not ask the notes workflow whether ignored readable-note edits are pending. That can publish a fresh root commit from stale `HEAD^{tree}` while `notes/status.md` (or another readable note) has local-only changes excluded from Git.

This adds a notes workflow gate before publication and a local-only regression test proving `publish-fresh --yes` refuses to push when `notes changes --summary` reports pending readable-note changes.

Validation:

- `bash -n .mise/lib/homes.sh .mise/tasks/homes/publish-fresh .mise/tasks/homes/commit-local .mise/tasks/homes/adopt-remote .mise/tasks/homes/smoke`
- `mise run test homes_publication`
- `mise run test`
- `git diff --check`
