### PR TITLE
homes: add auth and status readiness checks

### DIFF
--- a/.mise/lib/homes.sh
+++ b/.mise/lib/homes.sh
@@ -89,6 +89,58 @@ homes_json_string() {
   printf '"%s"' "$value"
 }
 
+homes_timeout_command() {
+  command -v timeout 2>/dev/null || command -v gtimeout 2>/dev/null
+}
+
+homes_git_is_repo() {
+  "$GIT_BIN" -C "$1" rev-parse --git-dir >/dev/null 2>&1
+}
+
+homes_git_head_label() {
+  local repo="$1" head branch
+  head=$("$GIT_BIN" -C "$repo" rev-parse --short HEAD 2>/dev/null) || return 1
+  branch=$("$GIT_BIN" -C "$repo" rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+  [ -n "$branch" ] || branch="detached"
+  [ "$branch" = "HEAD" ] && branch="detached"
+  printf '%s @ %s\n' "$branch" "$head"
+}
+
+homes_git_worktree_state() {
+  local repo="$1" status
+  if ! status=$("$GIT_BIN" -C "$repo" status --porcelain 2>/dev/null); then
+    printf 'unknown\n'
+    return 1
+  fi
+  if [ -z "$status" ]; then
+    printf 'clean\n'
+  else
+    printf 'dirty\n'
+  fi
+}
+
+homes_git_origin_redacted() {
+  local repo="$1" origin
+  origin=$("$GIT_BIN" -C "$repo" remote get-url origin 2>/dev/null) || return 1
+  homes_redact_url "$origin"
+}
+
+homes_manifest_state() {
+  local manifest="$1"
+  if [ ! -f "$manifest" ]; then
+    printf 'missing\n'
+  elif homes_file_is_gitcrypt_blob "$manifest"; then
+    printf 'locked\n'
+  else
+    printf 'readable\n'
+  fi
+}
+
+homes_notes_changes_summary() {
+  local home_path="$1"
+  (cd "$home_path" && "$NOTES_BIN" changes --summary)
+}
+
 homes_require_git_repo() {
   local home_path="$1"
 
@@ -107,13 +159,13 @@ homes_require_git_repo() {
 }
 
 homes_require_clean_worktree() {
-  local home_path="$1" status
+  local home_path="$1" state
 
-  if ! status=$("$GIT_BIN" -C "$home_path" status --porcelain); then
+  if ! state=$(homes_git_worktree_state "$home_path"); then
     echo "ERROR: could not inspect worktree: $home_path" >&2
     exit 1
   fi
-  if [ -n "$status" ]; then
+  if [ "$state" = "dirty" ]; then
     echo "ERROR: home worktree is dirty; commit/stash before continuing: $home_path" >&2
     "$GIT_BIN" -C "$home_path" status --short >&2
     exit 1
@@ -156,7 +208,7 @@ homes_require_no_pending_note_changes() {
     exit 1
   fi
 
-  if ! notes_changes=$(cd "$home_path" && "$NOTES_BIN" changes --summary 2>&1); then
+  if ! notes_changes=$(homes_notes_changes_summary "$home_path" 2>&1); then
     echo "ERROR: could not inspect notes workflow state before publishing" >&2
     printf '%s\n' "$notes_changes" >&2
     exit 1

--- a/.mise/lib/homes.sh
+++ b/.mise/lib/homes.sh
@@ -34,6 +34,61 @@ homes_resolve_home() {
   fi
 }
 
+homes_default_agents_root() {
+  printf '%s/agents\n' "$HOME"
+}
+
+homes_resolve_agents_root() {
+  local agents_root="$1"
+  if [ -n "$agents_root" ]; then
+    printf '%s\n' "$agents_root"
+  else
+    homes_default_agents_root
+  fi
+}
+
+homes_agent_dir() {
+  local agent="$1" agents_root="$2"
+  printf '%s/%s\n' "$agents_root" "$agent"
+}
+
+homes_agent_gitconfig_path() {
+  local agent="$1" agents_root="$2"
+  printf '%s/.gitconfig\n' "$(homes_agent_dir "$agent" "$agents_root")"
+}
+
+homes_agent_include_key() {
+  local agent="$1" agents_root="$2" agent_dir
+  if [ "$agents_root" = "$HOME/agents" ]; then
+    printf 'includeIf.gitdir:~/agents/%s/.path\n' "$agent"
+    return 0
+  fi
+  agent_dir=$(homes_agent_dir "$agent" "$agents_root")
+  printf 'includeIf.gitdir:%s/.path\n' "$agent_dir"
+}
+
+homes_infer_agent_from_home() {
+  local home_path="$1" base parent
+  [ -n "$home_path" ] || return 1
+  base=$(basename "$home_path")
+  parent=$(basename "$(dirname "$home_path")")
+  if [ "$base" = "home" ] && [ -n "$parent" ]; then
+    printf '%s\n' "$parent"
+    return 0
+  fi
+  return 1
+}
+
+homes_json_string() {
+  local value="$1"
+  value=${value//\\/\\\\}
+  value=${value//\"/\\\"}
+  value=${value//$'\n'/\\n}
+  value=${value//$'\r'/\\r}
+  value=${value//$'\t'/\\t}
+  printf '"%s"' "$value"
+}
+
 homes_require_git_repo() {
   local home_path="$1"
 
@@ -121,6 +176,21 @@ homes_blob_hex10() {
   hex=$(LC_ALL=C od -An -tx1 -N10 "$tmp" | tr -d ' \n')
   rm -f "$tmp"
   printf '%s\n' "$hex"
+}
+
+homes_file_hex10() {
+  local path="$1" tmp hex
+  tmp=$(mktemp)
+  LC_ALL=C od -An -tx1 -N10 "$path" > "$tmp"
+  hex=$(tr -d ' \n' < "$tmp")
+  rm -f "$tmp"
+  printf '%s\n' "$hex"
+}
+
+homes_file_is_gitcrypt_blob() {
+  local path="$1"
+  [ -f "$path" ] || return 1
+  [ "$(homes_file_hex10 "$path")" = "00474954435259505400" ]
 }
 
 homes_assert_gitcrypt_blob() {

--- a/.mise/lib/homes_render.sh
+++ b/.mise/lib/homes_render.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Small TSV-backed render helpers for homes:* tasks.
+# Source after homes.sh so homes_json_string is available.
+set -euo pipefail
+
+homes_render_record_row() {
+  local file="$1" label="$2" status="$3" detail="$4"
+  printf '%s\t%s\t%s\n' "$label" "$status" "$detail" >> "$file"
+}
+
+homes_render_status_badge() {
+  local status="$1" color_mode="$2"
+  case "$status" in
+    ok)
+      if [ "$color_mode" = "true" ]; then gum style --foreground 35 -- "✓ ok"; else printf '✓ ok'; fi ;;
+    warn)
+      if [ "$color_mode" = "true" ]; then gum style --foreground 214 -- "⚠ warn"; else printf '⚠ warn'; fi ;;
+    *)
+      if [ "$color_mode" = "true" ]; then gum style --foreground 160 -- "✗ fail"; else printf '✗ fail'; fi ;;
+  esac
+}
+
+homes_render_heading() {
+  local title="$1" color_mode="$2"
+  if [ "$color_mode" = "true" ]; then
+    gum style --bold -- "# $title"
+  else
+    printf '# %s\n' "$title"
+  fi
+  printf '\n'
+}
+
+homes_render_table() {
+  local file="$1" color_mode="$2" name status detail badge
+  if command -v gum >/dev/null 2>&1; then
+    {
+      printf 'Check\tStatus\tDetail\n'
+      while IFS=$'\t' read -r name status detail; do
+        [ -n "$name" ] || continue
+        badge=$(homes_render_status_badge "$status" "$color_mode")
+        printf '%s\t%s\t%s\n' "$name" "$badge" "$detail"
+      done < "$file"
+    } | gum table --print --separator $'\t' --border rounded
+  else
+    printf 'Check\tStatus\tDetail\n'
+    while IFS=$'\t' read -r name status detail; do
+      [ -n "$name" ] || continue
+      badge=$(homes_render_status_badge "$status" "$color_mode")
+      printf '%s\t%s\t%s\n' "$name" "$badge" "$detail"
+    done < "$file"
+  fi
+}
+
+homes_render_file_status() {
+  local file="$1" name status detail result=ok
+  while IFS=$'\t' read -r name status detail; do
+    [ -n "$name" ] || continue
+    if [ "$status" = fail ]; then
+      printf 'fail\n'
+      return 0
+    fi
+    [ "$status" = warn ] && result=warn
+  done < "$file"
+  printf '%s\n' "$result"
+}
+
+homes_render_file_has_failure() {
+  [ "$(homes_render_file_status "$1")" = fail ]
+}
+
+homes_render_file_warning_count() {
+  local file="$1" name status detail count=0
+  while IFS=$'\t' read -r name status detail; do
+    [ -n "$name" ] || continue
+    [ "$status" = warn ] && count=$((count + 1))
+  done < "$file"
+  printf '%s\n' "$count"
+}
+
+homes_render_json_section() {
+  local section="$1" file="$2" first_check=true name status detail
+  printf '{"name":'; homes_json_string "$section"
+  printf ',"checks":['
+  while IFS=$'\t' read -r name status detail; do
+    [ -n "$name" ] || continue
+    if [ "$first_check" = "true" ]; then first_check=false; else printf ','; fi
+    printf '{"name":'; homes_json_string "$name"
+    printf ',"status":'; homes_json_string "$status"
+    printf ',"detail":'; homes_json_string "$detail"
+    printf '}'
+  done < "$file"
+  printf ']}'
+}

--- a/.mise/lib/homes_render.sh
+++ b/.mise/lib/homes_render.sh
@@ -8,6 +8,11 @@ homes_render_record_row() {
   printf '%s\t%s\t%s\n' "$label" "$status" "$detail" >> "$file"
 }
 
+homes_render_record_check_row() {
+  local file="$1" group="$2" section="$3" label="$4" status="$5" detail="$6"
+  printf '%s\t%s\t%s\t%s\t%s\n' "$group" "$section" "$label" "$status" "$detail" >> "$file"
+}
+
 homes_render_status_badge() {
   local status="$1" color_mode="$2"
   case "$status" in
@@ -30,25 +35,34 @@ homes_render_heading() {
   printf '\n'
 }
 
-homes_render_table() {
-  local file="$1" color_mode="$2" name status detail badge
+homes_render_status_table_stream() {
+  local first_header="$1" color_mode="$2" name status detail badge
   if command -v gum >/dev/null 2>&1; then
     {
-      printf 'Check\tStatus\tDetail\n'
+      printf '%s\tStatus\tDetail\n' "$first_header"
       while IFS=$'\t' read -r name status detail; do
         [ -n "$name" ] || continue
         badge=$(homes_render_status_badge "$status" "$color_mode")
         printf '%s\t%s\t%s\n' "$name" "$badge" "$detail"
-      done < "$file"
+      done
     } | gum table --print --separator $'\t' --border rounded
   else
-    printf 'Check\tStatus\tDetail\n'
+    printf '%s\tStatus\tDetail\n' "$first_header"
     while IFS=$'\t' read -r name status detail; do
       [ -n "$name" ] || continue
       badge=$(homes_render_status_badge "$status" "$color_mode")
       printf '%s\t%s\t%s\n' "$name" "$badge" "$detail"
-    done < "$file"
+    done
   fi
+}
+
+homes_render_status_table() {
+  local first_header="$1" file="$2" color_mode="$3"
+  homes_render_status_table_stream "$first_header" "$color_mode" < "$file"
+}
+
+homes_render_table() {
+  homes_render_status_table "Check" "$1" "$2"
 }
 
 homes_render_file_status() {
@@ -90,4 +104,154 @@ homes_render_json_section() {
     printf '}'
   done < "$file"
   printf ']}'
+}
+
+homes_render_check_rows_section_title() {
+  local group="$1" section="$2"
+  if [ -z "$section" ] || [ "$section" = "$group" ]; then
+    printf '%s\n' "$group"
+  else
+    printf '%s: %s\n' "$group" "$section"
+  fi
+}
+
+homes_render_check_rows_group_status() {
+  local rows_file="$1" group="$2" row_group row_section name status detail result=ok found=false
+  while IFS=$'\t' read -r row_group row_section name status detail; do
+    [ -n "$row_group" ] || continue
+    [ "$row_group" = "$group" ] || continue
+    found=true
+    if [ "$status" = fail ]; then
+      printf 'fail\n'
+      return 0
+    fi
+    [ "$status" = warn ] && result=warn
+  done < "$rows_file"
+  if [ "$found" != "true" ]; then
+    printf 'warn\n'
+  else
+    printf '%s\n' "$result"
+  fi
+}
+
+homes_render_check_rows_has_failure() {
+  local rows_file="$1" row_group row_section name status detail
+  while IFS=$'\t' read -r row_group row_section name status detail; do
+    [ -n "$row_group" ] || continue
+    [ "$status" = fail ] && return 0
+  done < "$rows_file"
+  return 1
+}
+
+homes_render_check_rows_warning_count() {
+  local rows_file="$1" row_group row_section name status detail count=0
+  while IFS=$'\t' read -r row_group row_section name status detail; do
+    [ -n "$row_group" ] || continue
+    [ "$status" = warn ] && count=$((count + 1))
+  done < "$rows_file"
+  printf '%s\n' "$count"
+}
+
+homes_render_check_rows_first_non_ok_detail() {
+  local rows_file="$1" group="$2" row_group row_section name status detail
+  while IFS=$'\t' read -r row_group row_section name status detail; do
+    [ -n "$row_group" ] || continue
+    [ "$row_group" = "$group" ] || continue
+    [ "$status" = ok ] && continue
+    if [ "$row_section" = "$group" ] || [ -z "$row_section" ]; then
+      printf '%s: %s\n' "$name" "$detail"
+    else
+      printf '%s / %s: %s\n' "$row_section" "$name" "$detail"
+    fi
+    return 0
+  done < "$rows_file"
+  printf 'review details\n'
+}
+
+homes_render_check_rows_detail() {
+  local rows_file="$1" group="$2" section="$3" label="$4" row_group row_section name status detail
+  while IFS=$'\t' read -r row_group row_section name status detail; do
+    [ "$row_group" = "$group" ] || continue
+    [ "$row_section" = "$section" ] || continue
+    [ "$name" = "$label" ] || continue
+    printf '%s\n' "$detail"
+    return 0
+  done < "$rows_file"
+  return 1
+}
+
+homes_render_check_rows_count_ok_prefixed() {
+  local rows_file="$1" group="$2" prefix="$3" row_group row_section name status detail count=0
+  while IFS=$'\t' read -r row_group row_section name status detail; do
+    [ "$row_group" = "$group" ] || continue
+    case "$name" in
+      "$prefix"*) [ "$status" = ok ] && count=$((count + 1)) ;;
+    esac
+  done < "$rows_file"
+  printf '%s\n' "$count"
+}
+
+homes_render_check_rows_group_sections() {
+  local rows_file="$1" group="$2" row_group row_section name status detail last_section=""
+  while IFS=$'\t' read -r row_group row_section name status detail; do
+    [ -n "$row_group" ] || continue
+    [ "$row_group" = "$group" ] || continue
+    [ "$row_section" = "$last_section" ] && continue
+    printf '%s\n' "$row_section"
+    last_section="$row_section"
+  done < "$rows_file"
+}
+
+homes_render_check_rows_section_table() {
+  local rows_file="$1" group="$2" section="$3" color_mode="$4" row_group row_section name status detail
+  homes_render_status_table_stream "Check" "$color_mode" < <(
+    while IFS=$'\t' read -r row_group row_section name status detail; do
+      [ "$row_group" = "$group" ] || continue
+      [ "$row_section" = "$section" ] || continue
+      printf '%s\t%s\t%s\n' "$name" "$status" "$detail"
+    done < "$rows_file"
+  )
+}
+
+homes_render_check_rows_print_failed_groups() {
+  local rows_file="$1" color_mode="$2" group section status title
+  shift 2
+  for group in "$@"; do
+    status=$(homes_render_check_rows_group_status "$rows_file" "$group")
+    [ "$status" = ok ] && continue
+    while IFS= read -r section; do
+      title=$(homes_render_check_rows_section_title "$group" "$section")
+      printf '\n'
+      homes_render_heading "$title" "$color_mode"
+      homes_render_check_rows_section_table "$rows_file" "$group" "$section" "$color_mode"
+    done < <(homes_render_check_rows_group_sections "$rows_file" "$group")
+  done
+}
+
+homes_render_check_rows_json_sections() {
+  local rows_file="$1" row_group row_section name status detail key current_key="" first_section=true first_check=true title
+  while IFS=$'\t' read -r row_group row_section name status detail; do
+    [ -n "$row_group" ] || continue
+    key="$row_group"$'\t'"$row_section"
+    if [ "$key" != "$current_key" ]; then
+      if [ -n "$current_key" ]; then
+        printf ']}'
+      fi
+      if [ "$first_section" = "true" ]; then first_section=false; else printf ','; fi
+      title=$(homes_render_check_rows_section_title "$row_group" "$row_section")
+      printf '{"name":'; homes_json_string "$title"
+      printf ',"checks":['
+      current_key="$key"
+      first_check=true
+    fi
+
+    if [ "$first_check" = "true" ]; then first_check=false; else printf ','; fi
+    printf '{"name":'; homes_json_string "$name"
+    printf ',"status":'; homes_json_string "$status"
+    printf ',"detail":'; homes_json_string "$detail"
+    printf '}'
+  done < "$rows_file"
+  if [ -n "$current_key" ]; then
+    printf ']}'
+  fi
 }

--- a/.mise/tasks/homes/auth/_default
+++ b/.mise/tasks/homes/auth/_default
@@ -1,0 +1,291 @@
+#!/usr/bin/env bash
+#MISE description="Show local auth/signing readiness for an agent home"
+#USAGE flag "--agents-root <path>" default="" help="Agents workspace root (default: ~/agents)"
+#USAGE flag "--home <path>" default="" help="Home repo path (default: <agents-root>/<agent>/home)"
+#USAGE flag "--json" default=#false help="Emit machine-readable JSON"
+#USAGE flag "--check" default=#false help="Exit nonzero when local auth is not ready"
+#USAGE arg "[agent]" default="" help="Agent name"
+set -euo pipefail
+
+ROOT="${MISE_CONFIG_ROOT:?MISE_CONFIG_ROOT not set}"
+# shellcheck source=.mise/lib/homes.sh
+source "$ROOT/.mise/lib/homes.sh"
+# shellcheck source=.mise/lib/homes_render.sh
+source "$ROOT/.mise/lib/homes_render.sh"
+
+AGENT="${usage_agent:-iris}"
+HOME_PATH="${usage_home:-}"
+AGENTS_ROOT=$(homes_resolve_agents_root "${usage_agents_root:-}")
+JSON="${usage_json:-false}"
+CHECK="${usage_check:-false}"
+validate_agent "$AGENT"
+
+if [ -z "$HOME_PATH" ]; then
+  HOME_PATH="$AGENTS_ROOT/$AGENT/home"
+fi
+EMAIL=$(homes_agent_email "$AGENT")
+AGENT_DIR=$(homes_agent_dir "$AGENT" "$AGENTS_ROOT")
+GITCONFIG=$(homes_agent_gitconfig_path "$AGENT" "$AGENTS_ROOT")
+INCLUDE_KEY=$(homes_agent_include_key "$AGENT" "$AGENTS_ROOT")
+
+TEXT_MODE=true
+[ "$JSON" = "true" ] && TEXT_MODE=false
+SPINNER_MODE=false
+if [ "$TEXT_MODE" = "true" ] && [ -t 0 ] && [ -w /dev/tty ] && command -v gum >/dev/null 2>&1; then
+  SPINNER_MODE=true
+fi
+COLOR_MODE="$SPINNER_MODE"
+PHASE_COUNT=0
+PHASE_NAMES=()
+PHASE_FILES=()
+
+TMP_ROOT=$(mktemp -d)
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+record_row() {
+  homes_render_record_row "$PHASE_OUT" "$@"
+}
+
+parse_github_expiry_epoch() {
+  local value="$1" epoch
+  if epoch=$(date -u -d "$value" +%s 2>/dev/null); then
+    printf '%s\n' "$epoch"
+    return 0
+  fi
+  if epoch=$(date -j -u -f "%Y-%m-%d %H:%M:%S %Z" "$value" +%s 2>/dev/null); then
+    printf '%s\n' "$epoch"
+    return 0
+  fi
+  return 1
+}
+
+check_secrets() {
+  local key label value
+
+  if ! command -v "$SECRETS_BIN" >/dev/null 2>&1; then
+    record_row "Secrets tool" fail "not available"
+    record_row "GPG fingerprint" fail "secrets tool unavailable"
+    record_row "GPG private key" fail "secrets tool unavailable"
+    record_row "GitHub username" fail "secrets tool unavailable"
+    record_row "GitHub PAT" fail "secrets tool unavailable"
+    return 0
+  fi
+
+  record_row "Secrets tool" ok "available"
+  while IFS='|' read -r key label; do
+    [ -n "$key" ] || continue
+    if value=$("$SECRETS_BIN" get "$AGENT/$key" 2>/dev/null) && [ -n "$value" ]; then
+      record_row "$label" ok "present"
+    else
+      record_row "$label" fail "missing or empty"
+    fi
+    unset value
+  done <<'EOF_SECRETS'
+gpg-fingerprint|GPG fingerprint
+gpg-private-key|GPG private key
+github-username|GitHub username
+github-pat|GitHub PAT
+EOF_SECRETS
+}
+
+check_signing() {
+  local fingerprint configured_name configured_email configured_key configured_sign include_values
+
+  if ! fingerprint=$("$SECRETS_BIN" get "$AGENT/gpg-fingerprint" 2>/dev/null) || [ -z "$fingerprint" ]; then
+    record_row "GPG secret key" fail "skipped; no stored fingerprint"
+  elif ! command -v "$GPG_BIN" >/dev/null 2>&1; then
+    record_row "GPG secret key" fail "gpg tool unavailable"
+  elif "$GPG_BIN" --list-secret-keys "$fingerprint" >/dev/null 2>&1; then
+    record_row "GPG secret key" ok "present for stored fingerprint"
+  else
+    record_row "GPG secret key" fail "missing for stored fingerprint"
+  fi
+
+  if [ -f "$GITCONFIG" ]; then
+    configured_name=$("$GIT_BIN" config --file "$GITCONFIG" user.name 2>/dev/null || true)
+    configured_email=$("$GIT_BIN" config --file "$GITCONFIG" user.email 2>/dev/null || true)
+    configured_key=$("$GIT_BIN" config --file "$GITCONFIG" user.signingkey 2>/dev/null || true)
+    configured_sign=$("$GIT_BIN" config --file "$GITCONFIG" commit.gpgsign 2>/dev/null || true)
+    if [ "$configured_name" = "$AGENT" ] && [ "$configured_email" = "$EMAIL" ] && [ -n "${fingerprint:-}" ] && [ "$configured_key" = "$fingerprint" ] && [ "$configured_sign" = "true" ]; then
+      record_row "Git config" ok "$GITCONFIG"
+    else
+      record_row "Git config" fail "present but does not match expected agent identity"
+    fi
+  else
+    record_row "Git config" fail "missing $GITCONFIG"
+  fi
+
+  include_values=""
+  if include_values=$("$GIT_BIN" config --global --get-all "$INCLUDE_KEY" 2>/dev/null); then
+    :
+  else
+    include_values=""
+  fi
+  if printf '%s\n' "$include_values" | grep -Fxq "$GITCONFIG"; then
+    record_row "Git includeIf" ok "$INCLUDE_KEY"
+  else
+    record_row "Git includeIf" fail "missing include for $AGENT_DIR"
+  fi
+}
+
+check_github() {
+  local username token response login expiry epoch now days note
+
+  if ! username=$("$SECRETS_BIN" get "$AGENT/github-username" 2>/dev/null) || [ -z "$username" ]; then
+    record_row "GitHub token" fail "missing GitHub username secret"
+    return 0
+  fi
+  if ! token=$("$SECRETS_BIN" get "$AGENT/github-pat" 2>/dev/null) || [ -z "$token" ]; then
+    record_row "GitHub token" fail "missing GitHub PAT secret"
+    return 0
+  fi
+  if ! command -v "$GH_BIN" >/dev/null 2>&1; then
+    record_row "GitHub token" fail "gh tool unavailable"
+    return 0
+  fi
+
+  if ! response=$(GH_TOKEN="$token" "$GH_BIN" api /user -i 2>&1); then
+    record_row "GitHub token" fail "validation failed"
+    return 0
+  fi
+  unset token
+
+  login=$(printf '%s\n' "$response" | sed -n 's/.*"login"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
+  [ -n "$login" ] || login="-"
+  if [ "$login" != "$username" ]; then
+    record_row "GitHub token" fail "valid as $login, expected $username"
+    return 0
+  fi
+
+  expiry=$(printf '%s\n' "$response" | awk '
+    tolower($0) ~ /^github-authentication-token-expiration:/ {
+      sub(/^[^:]*:[[:space:]]*/, "")
+      sub(/\r$/, "")
+      print
+      exit
+    }
+  ')
+
+  if [ -z "$expiry" ]; then
+    record_row "GitHub token" ok "valid as $username; no expiration"
+    return 0
+  fi
+
+  if epoch=$(parse_github_expiry_epoch "$expiry"); then
+    now=$(date -u +%s)
+    days=$(( (epoch - now) / 86400 ))
+    note=""
+    if [ "$days" -lt 0 ]; then
+      note="; expired"
+    elif [ "$days" -le 7 ]; then
+      note="; rotate soon"
+    fi
+    record_row "GitHub token" ok "valid as $username; expires in $days day(s)$note"
+  else
+    record_row "GitHub token" ok "valid as $username; expires $expiry"
+  fi
+}
+
+run_phase_check() {
+  local check_func="$1" out_file="$2"
+  PHASE_OUT="$out_file"
+  export PHASE_OUT AGENT EMAIL AGENT_DIR GITCONFIG INCLUDE_KEY GIT_BIN GPG_BIN GH_BIN SECRETS_BIN
+  export -f homes_render_record_row record_row parse_github_expiry_epoch check_secrets check_signing check_github
+
+  if [ "$SPINNER_MODE" = "true" ]; then
+    PHASE_OUT="$out_file" gum spin --title "$PHASE_SPINNER" -- bash -c '
+      set -euo pipefail
+      start=$SECONDS
+      status=0
+      "$1" || status=$?
+      elapsed=$((SECONDS - start))
+      [ "$elapsed" -lt 1 ] && sleep $((1 - elapsed))
+      exit "$status"
+    ' phase-runner "$check_func"
+  else
+    "$check_func"
+  fi
+}
+
+run_phase() {
+  local title="$1" spinner="$2" check_func="$3" out_file
+  out_file="$TMP_ROOT/${title// /-}.tsv"
+  : > "$out_file"
+  PHASE_NAMES+=("$title")
+  PHASE_FILES+=("$out_file")
+
+  if [ "$TEXT_MODE" = "true" ]; then
+    [ "$PHASE_COUNT" -gt 0 ] && printf '\n'
+    PHASE_SPINNER="$spinner" run_phase_check "$check_func" "$out_file"
+    homes_render_heading "$title" "$COLOR_MODE"
+    homes_render_table "$out_file" "$COLOR_MODE"
+  else
+    PHASE_SPINNER="$spinner" run_phase_check "$check_func" "$out_file"
+  fi
+
+  PHASE_COUNT=$((PHASE_COUNT + 1))
+}
+
+is_ready() {
+  local file name status detail
+  for file in ${PHASE_FILES[@]+"${PHASE_FILES[@]}"}; do
+    while IFS=$'\t' read -r name status detail; do
+      [ -n "$name" ] || continue
+      [ "$status" = ok ] || return 1
+    done < "$file"
+  done
+  return 0
+}
+
+auth_next() {
+  if is_ready; then
+    printf 'auth ready\n'
+  else
+    printf 'auth setup needed; homes:auth:setup is pending follow-up\n'
+  fi
+}
+
+print_next() {
+  [ "$TEXT_MODE" = "true" ] || return 0
+  printf '\n'
+  homes_render_heading "Next" "$COLOR_MODE"
+  auth_next
+}
+
+print_json() {
+  local ready="true" i file first_section="true" first_check name status detail next
+  is_ready || ready="false"
+  next=$(auth_next)
+
+  printf '{'
+  printf '"agent":'; homes_json_string "$AGENT"
+  printf ',"home":'; homes_json_string "$HOME_PATH"
+  printf ',"ready":%s' "$ready"
+  printf ',"next":'; homes_json_string "$next"
+  printf ',"sections":['
+  for ((i = 0; i < ${#PHASE_NAMES[@]}; i++)); do
+    if [ "$first_section" = "true" ]; then first_section="false"; else printf ','; fi
+    file="${PHASE_FILES[$i]}"
+    homes_render_json_section "${PHASE_NAMES[$i]}" "$file"
+  done
+  printf ']}'
+  printf '\n'
+}
+
+if [ "$TEXT_MODE" = "true" ]; then
+  printf 'Homes auth: %s\n\n' "$AGENT"
+fi
+
+run_phase "Secrets" "Checking: secrets" check_secrets
+run_phase "Signing" "Checking: signing" check_signing
+run_phase "GitHub" "Checking: GitHub token" check_github
+print_next
+
+if [ "$JSON" = "true" ]; then
+  print_json
+fi
+
+if [ "$CHECK" = "true" ] && ! is_ready; then
+  exit 1
+fi
+exit 0

--- a/.mise/tasks/homes/status
+++ b/.mise/tasks/homes/status
@@ -1,0 +1,562 @@
+#!/usr/bin/env bash
+#MISE description="Show aggregate read-only readiness for an agent home"
+#USAGE flag "--agents-root <path>" default="" help="Agents workspace root (default: ~/agents)"
+#USAGE flag "--home <path>" default="" help="Home repo path (default: <agents-root>/<agent>/home)"
+#USAGE flag "--json" default=#false help="Emit machine-readable JSON"
+#USAGE flag "--check" default=#false help="Exit nonzero when the home is not ready"
+#USAGE arg "[agent]" default="" help="Agent name"
+#USAGE example "mise run homes:status iris" header="Show Iris home readiness"
+#USAGE example "mise run homes:status iris --json --check" header="Machine-check Iris home readiness"
+set -euo pipefail
+
+ROOT="${MISE_CONFIG_ROOT:?MISE_CONFIG_ROOT not set}"
+# shellcheck source=.mise/lib/homes.sh
+source "$ROOT/.mise/lib/homes.sh"
+# shellcheck source=.mise/lib/homes_render.sh
+source "$ROOT/.mise/lib/homes_render.sh"
+
+AGENT="${usage_agent:-iris}"
+HOME_PATH="${usage_home:-}"
+AGENTS_ROOT=$(homes_resolve_agents_root "${usage_agents_root:-}")
+JSON="${usage_json:-false}"
+CHECK="${usage_check:-false}"
+JQ_BIN="${JQ:-jq}"
+validate_agent "$AGENT"
+
+if [ -z "$HOME_PATH" ]; then
+  HOME_PATH="$AGENTS_ROOT/$AGENT/home"
+fi
+
+TEXT_MODE=true
+[ "$JSON" = "true" ] && TEXT_MODE=false
+COLOR_MODE=false
+if [ "$TEXT_MODE" = "true" ] && [ -t 1 ] && command -v gum >/dev/null 2>&1; then
+  COLOR_MODE=true
+fi
+
+SECTION_COUNT=0
+SECTION_NAMES=()
+SECTION_FILES=()
+NEXT_ACTION=""
+HOME_EXISTS=false
+HOME_IS_GIT=false
+
+TMP_ROOT=$(mktemp -d)
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+set_next_once() {
+  local action="$1"
+  if [ -z "$NEXT_ACTION" ]; then
+    NEXT_ACTION="$action"
+  fi
+}
+
+begin_section() {
+  local title="$1" out_file
+  out_file="$TMP_ROOT/section-$SECTION_COUNT.tsv"
+  : > "$out_file"
+  SECTION_NAMES+=("$title")
+  SECTION_FILES+=("$out_file")
+  SECTION_OUT="$out_file"
+  SECTION_COUNT=$((SECTION_COUNT + 1))
+}
+
+record_row() {
+  homes_render_record_row "$SECTION_OUT" "$@"
+}
+
+record_fail() {
+  local label="$1" detail="$2" next="$3"
+  record_row "$label" fail "$detail"
+  set_next_once "$next"
+}
+
+run_section() {
+  local title="$1" check_func="$2"
+  begin_section "$title"
+  "$check_func"
+}
+
+section_in_group() {
+  local section="$1" group="$2"
+  case "$section" in
+    "$group"|"$group: "*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+group_status() {
+  local group="$1" i section status result=ok found=false
+  for ((i = 0; i < ${#SECTION_NAMES[@]}; i++)); do
+    section="${SECTION_NAMES[$i]}"
+    section_in_group "$section" "$group" || continue
+    found=true
+    status=$(homes_render_file_status "${SECTION_FILES[$i]}")
+    if [ "$status" = fail ]; then
+      printf 'fail\n'
+      return 0
+    fi
+    [ "$status" = warn ] && result=warn
+  done
+  if [ "$found" != "true" ]; then
+    printf 'warn\n'
+  else
+    printf '%s\n' "$result"
+  fi
+}
+
+group_first_non_ok_detail() {
+  local group="$1" i section file name status detail
+  for ((i = 0; i < ${#SECTION_NAMES[@]}; i++)); do
+    section="${SECTION_NAMES[$i]}"
+    section_in_group "$section" "$group" || continue
+    file="${SECTION_FILES[$i]}"
+    while IFS=$'\t' read -r name status detail; do
+      [ -n "$name" ] || continue
+      [ "$status" = ok ] && continue
+      if [ "$section" = "$group" ]; then
+        printf '%s: %s\n' "$name" "$detail"
+      else
+        printf '%s / %s: %s\n' "${section#$group: }" "$name" "$detail"
+      fi
+      return 0
+    done < "$file"
+  done
+  printf 'review details\n'
+}
+
+section_detail() {
+  local group="$1" label="$2" file name status detail
+  for ((i = 0; i < ${#SECTION_NAMES[@]}; i++)); do
+    [ "${SECTION_NAMES[$i]}" = "$group" ] || continue
+    file="${SECTION_FILES[$i]}"
+    while IFS=$'\t' read -r name status detail; do
+      [ "$name" = "$label" ] || continue
+      printf '%s\n' "$detail"
+      return 0
+    done < "$file"
+  done
+  return 1
+}
+
+group_ok_detail() {
+  local group="$1" head modules=0
+  case "$group" in
+    Auth)
+      printf 'ready\n'
+      ;;
+    Home)
+      head=$(section_detail Home HEAD || true)
+      if [ -n "$head" ]; then
+        printf 'clean %s\n' "$head"
+      else
+        printf 'ready\n'
+      fi
+      ;;
+    Notes)
+      printf 'clean\n'
+      ;;
+    Modules)
+      modules=$(count_module_rows)
+      printf '%s module(s) at pin\n' "$modules"
+      ;;
+    *)
+      printf 'ready\n'
+      ;;
+  esac
+}
+
+group_detail() {
+  local group="$1" status="$2"
+  if [ "$status" = ok ]; then
+    group_ok_detail "$group"
+  else
+    group_first_non_ok_detail "$group"
+  fi
+}
+
+section_warning_count() {
+  local file count=0
+  for file in ${SECTION_FILES[@]+"${SECTION_FILES[@]}"}; do
+    count=$((count + $(homes_render_file_warning_count "$file")))
+  done
+  printf '%s\n' "$count"
+}
+
+section_has_failures() {
+  local file
+  for file in ${SECTION_FILES[@]+"${SECTION_FILES[@]}"}; do
+    homes_render_file_has_failure "$file" && return 0
+  done
+  return 1
+}
+
+is_ready() {
+  ! section_has_failures
+}
+
+count_module_rows() {
+  local i file name status detail count=0
+  for ((i = 0; i < ${#SECTION_NAMES[@]}; i++)); do
+    [ "${SECTION_NAMES[$i]}" = "Modules" ] || continue
+    file="${SECTION_FILES[$i]}"
+    while IFS=$'\t' read -r name status detail; do
+      case "$name" in
+        module:*) [ "$status" = ok ] && count=$((count + 1)) ;;
+      esac
+    done < "$file"
+  done
+  printf '%s\n' "$count"
+}
+
+timeout_command() {
+  command -v timeout 2>/dev/null || command -v gtimeout 2>/dev/null
+}
+
+collect_auth() {
+  local auth_output auth_status=0 auth_rows auth_next current_section section name status detail timeout_bin auth_timeout auth_stderr
+  auth_rows="$TMP_ROOT/auth.tsv"
+  auth_stderr="$TMP_ROOT/auth.stderr"
+  auth_timeout="${HOMES_STATUS_AUTH_TIMEOUT:-20}"
+
+  if ! command -v "$JQ_BIN" >/dev/null 2>&1; then
+    begin_section "Auth"
+    record_fail "jq" "not available for parsing homes:auth JSON" "mise install"
+    return 0
+  fi
+
+  if timeout_bin=$(timeout_command); then
+    if auth_output=$(
+      cd "$ROOT" && "$timeout_bin" "$auth_timeout" mise run -q homes:auth "$AGENT" \
+        --agents-root "$AGENTS_ROOT" \
+        --home "$HOME_PATH" \
+        --json \
+        --check 2>"$auth_stderr"
+    ); then
+      auth_status=0
+    else
+      auth_status=$?
+    fi
+  elif auth_output=$(
+    cd "$ROOT" && mise run -q homes:auth "$AGENT" \
+      --agents-root "$AGENTS_ROOT" \
+      --home "$HOME_PATH" \
+      --json \
+      --check 2>"$auth_stderr"
+  ); then
+    auth_status=0
+  else
+    auth_status=$?
+  fi
+
+  if [ "$auth_status" -eq 124 ]; then
+    begin_section "Auth"
+    record_fail "homes:auth" "timed out after ${auth_timeout}s" "mise run homes:auth $AGENT --home $HOME_PATH"
+    return 0
+  fi
+
+  if [ "$auth_status" -ne 0 ] && [ "$auth_status" -ne 1 ]; then
+    begin_section "Auth"
+    record_fail "homes:auth" "failed unexpectedly (exit $auth_status)" "mise run homes:auth $AGENT --home $HOME_PATH"
+    return 0
+  fi
+
+  if ! printf '%s' "$auth_output" | "$JQ_BIN" -r '.sections[] as $section | $section.checks[] | [$section.name, .name, .status, .detail] | @tsv' > "$auth_rows"; then
+    begin_section "Auth"
+    record_fail "homes:auth" "did not emit parseable JSON" "mise run homes:auth $AGENT --json"
+    return 0
+  fi
+
+  auth_next=$(printf '%s' "$auth_output" | "$JQ_BIN" -r '.next // empty')
+  [ "$auth_status" -eq 1 ] && set_next_once "${auth_next:-auth setup needed; setup task is pending follow-up}"
+
+  current_section=""
+  while IFS=$'\t' read -r section name status detail; do
+    [ -n "$section" ] || continue
+    if [ "$section" != "$current_section" ]; then
+      begin_section "Auth: $section"
+      current_section="$section"
+    fi
+    record_row "$name" "$status" "$detail"
+  done < "$auth_rows"
+
+  if [ "$current_section" = "" ]; then
+    begin_section "Auth"
+    record_fail "homes:auth" "emitted no checks" "mise run homes:auth $AGENT --json"
+  fi
+}
+
+check_home() {
+  local status head branch origin
+
+  if [ ! -e "$HOME_PATH" ]; then
+    HOME_EXISTS=false
+    record_fail "Home path" "missing $HOME_PATH" "mise run homes:adopt-remote $AGENT --repo <owner/repo> --yes"
+    return 0
+  fi
+  HOME_EXISTS=true
+
+  if [ ! -d "$HOME_PATH" ]; then
+    record_fail "Home path" "not a directory: $HOME_PATH" "resolve home path before continuing"
+    return 0
+  fi
+  record_row "Home path" ok "$HOME_PATH"
+
+  if ! "$GIT_BIN" -C "$HOME_PATH" rev-parse --git-dir >/dev/null 2>&1; then
+    HOME_IS_GIT=false
+    record_fail "Git repo" "not a git repository" "clone or adopt the agent home repo"
+    return 0
+  fi
+  HOME_IS_GIT=true
+  record_row "Git repo" ok "present"
+
+  if head=$("$GIT_BIN" -C "$HOME_PATH" rev-parse --short HEAD 2>/dev/null); then
+    branch=$("$GIT_BIN" -C "$HOME_PATH" rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+    [ -n "$branch" ] || branch="detached"
+    [ "$branch" = "HEAD" ] && branch="detached"
+    record_row "HEAD" ok "$branch @ $head"
+  else
+    record_fail "HEAD" "no commits" "finish or adopt the home bootstrap commit"
+  fi
+
+  if status=$("$GIT_BIN" -C "$HOME_PATH" status --porcelain 2>/dev/null); then
+    if [ -z "$status" ]; then
+      record_row "Worktree" ok "clean"
+    else
+      record_fail "Worktree" "dirty; run git status --short in the home" "git -C $HOME_PATH status --short"
+    fi
+  else
+    record_fail "Worktree" "could not inspect worktree" "git -C $HOME_PATH status --short"
+  fi
+
+  if origin=$("$GIT_BIN" -C "$HOME_PATH" remote get-url origin 2>/dev/null); then
+    record_row "Origin" ok "$(homes_redact_url "$origin")"
+  else
+    record_row "Origin" warn "not configured"
+  fi
+
+  if [ -f "$HOME_PATH/AGENTS.md" ]; then
+    record_row "AGENTS.md" ok "present"
+  else
+    record_fail "AGENTS.md" "missing" "restore or render the home scaffold"
+  fi
+
+  if [ -f "$HOME_PATH/mise.toml" ]; then
+    record_row "mise.toml" ok "present"
+  else
+    record_row "mise.toml" warn "missing"
+  fi
+
+  if [ -x "$HOME_PATH/.mise/tasks/agent/prepare" ]; then
+    record_row "agent:prepare" ok "present"
+  else
+    record_row "agent:prepare" warn "missing"
+  fi
+}
+
+check_notes() {
+  local manifest notes_changes tracked_readable
+  manifest="$HOME_PATH/notes/.manifest"
+
+  if [ "$HOME_EXISTS" != "true" ] || [ ! -d "$HOME_PATH" ]; then
+    record_row "Notes" warn "skipped; home path unavailable"
+    return 0
+  fi
+
+  if [ ! -d "$HOME_PATH/notes" ]; then
+    record_row "Notes dir" warn "missing notes/"
+    return 0
+  fi
+  record_row "Notes dir" ok "present"
+
+  if [ ! -f "$manifest" ]; then
+    record_row "Notes manifest" warn "missing notes/.manifest"
+  elif homes_file_is_gitcrypt_blob "$manifest"; then
+    record_fail "Notes manifest" "locked git-crypt blob" "cd $HOME_PATH && notes unlock"
+  else
+    record_row "Notes manifest" ok "readable"
+
+    if ! command -v "$NOTES_BIN" >/dev/null 2>&1; then
+      record_fail "Notes tool" "not available" "install notes or run mise install in the home"
+    elif notes_changes=$(cd "$HOME_PATH" && "$NOTES_BIN" changes --summary 2>&1); then
+      if [ "$notes_changes" = "No changes." ]; then
+        record_row "Notes changes" ok "clean"
+      else
+        record_fail "Notes changes" "pending readable note changes" "cd $HOME_PATH && notes changes --summary"
+      fi
+    else
+      record_fail "Notes changes" "could not inspect notes workflow" "cd $HOME_PATH && notes changes --summary"
+    fi
+  fi
+
+  if [ "$HOME_IS_GIT" = "true" ]; then
+    if ! tracked_readable=$("$GIT_BIN" -C "$HOME_PATH" ls-files 'notes/*.md' 2>/dev/null); then
+      tracked_readable=""
+    fi
+    if [ -n "$tracked_readable" ]; then
+      record_fail "Tracked readable notes" "readable notes/*.md are tracked" "cd $HOME_PATH && notes stage"
+    else
+      record_row "Tracked readable notes" ok "none"
+    fi
+  fi
+}
+
+check_modules() {
+  local manifest name url pin track module_dir head any_modules=false
+  manifest="$HOME_PATH/.modules/manifest"
+
+  if [ "$HOME_EXISTS" != "true" ] || [ ! -d "$HOME_PATH" ]; then
+    record_row "Modules" warn "skipped; home path unavailable"
+    return 0
+  fi
+
+  if [ ! -f "$manifest" ]; then
+    record_row "Modules manifest" warn "missing .modules/manifest"
+    return 0
+  fi
+
+  if homes_file_is_gitcrypt_blob "$manifest"; then
+    record_fail "Modules manifest" "locked git-crypt blob" "cd $HOME_PATH && modules unlock"
+    return 0
+  fi
+  record_row "Modules manifest" ok "readable"
+
+  if command -v "$MODULES_BIN" >/dev/null 2>&1; then
+    record_row "Modules tool" ok "available"
+  else
+    record_fail "Modules tool" "not available" "install modules or run mise install in the home"
+  fi
+
+  while IFS=$'\t' read -r name url pin track; do
+    [ -n "$name" ] || continue
+    any_modules=true
+    head=""
+    module_dir="$HOME_PATH/modules/$name"
+    if [ ! -d "$module_dir" ]; then
+      record_fail "module:$name" "missing clone" "cd $HOME_PATH && modules init"
+      continue
+    fi
+    if ! "$GIT_BIN" -C "$module_dir" rev-parse --git-dir >/dev/null 2>&1; then
+      record_fail "module:$name" "not a git repository" "cd $HOME_PATH && modules init"
+      continue
+    fi
+    if head=$("$GIT_BIN" -C "$module_dir" rev-parse HEAD 2>/dev/null) && [ -n "$pin" ] && [ "$head" = "$pin" ]; then
+      record_row "module:$name" ok "at pin ${pin:0:12}"
+    elif [ -n "${head:-}" ] && [ -n "$pin" ]; then
+      record_fail "module:$name" "at ${head:0:12}; expected ${pin:0:12}" "cd $HOME_PATH && modules init"
+    else
+      record_fail "module:$name" "could not inspect pin" "cd $HOME_PATH && modules status"
+    fi
+  done < "$manifest"
+
+  if [ "$any_modules" != "true" ]; then
+    record_row "Modules" warn "manifest has no modules"
+  fi
+}
+
+default_next_action() {
+  local warnings
+  if [ -n "$NEXT_ACTION" ]; then
+    printf '%s\n' "$NEXT_ACTION"
+    return 0
+  fi
+  warnings=$(section_warning_count)
+  if [ "$warnings" -gt 0 ]; then
+    printf 'review warnings above\n'
+  else
+    printf 'home ready\n'
+  fi
+}
+
+print_summary() {
+  local group status detail badge
+  homes_render_heading "Summary" "$COLOR_MODE"
+  if command -v gum >/dev/null 2>&1; then
+    {
+      printf 'Section\tStatus\tDetail\n'
+      for group in Auth Home Notes Modules; do
+        status=$(group_status "$group")
+        detail=$(group_detail "$group" "$status")
+        badge=$(homes_render_status_badge "$status" "$COLOR_MODE")
+        printf '%s\t%s\t%s\n' "$group" "$badge" "$detail"
+      done
+    } | gum table --print --separator $'\t' --border rounded
+  else
+    printf 'Section\tStatus\tDetail\n'
+    for group in Auth Home Notes Modules; do
+      status=$(group_status "$group")
+      detail=$(group_detail "$group" "$status")
+      badge=$(homes_render_status_badge "$status" "$COLOR_MODE")
+      printf '%s\t%s\t%s\n' "$group" "$badge" "$detail"
+    done
+  fi
+}
+
+print_expanded_sections() {
+  local group status i section printed=false
+  for group in Auth Home Notes Modules; do
+    status=$(group_status "$group")
+    [ "$status" = ok ] && continue
+    for ((i = 0; i < ${#SECTION_NAMES[@]}; i++)); do
+      section="${SECTION_NAMES[$i]}"
+      section_in_group "$section" "$group" || continue
+      printf '\n'
+      homes_render_heading "$section" "$COLOR_MODE"
+      homes_render_table "${SECTION_FILES[$i]}" "$COLOR_MODE"
+      printed=true
+    done
+  done
+  $printed || return 0
+}
+
+print_next() {
+  [ "$TEXT_MODE" = "true" ] || return 0
+  printf '\n'
+  homes_render_heading "Next" "$COLOR_MODE"
+  default_next_action
+}
+
+print_json() {
+  local ready="true" warnings next i file first_section="true"
+  is_ready || ready="false"
+  warnings=$(section_warning_count)
+  next=$(default_next_action)
+
+  printf '{'
+  printf '"agent":'; homes_json_string "$AGENT"
+  printf ',"home":'; homes_json_string "$HOME_PATH"
+  printf ',"ready":%s' "$ready"
+  printf ',"warnings":%s' "$warnings"
+  printf ',"next":'; homes_json_string "$next"
+  printf ',"sections":['
+  for ((i = 0; i < ${#SECTION_NAMES[@]}; i++)); do
+    if [ "$first_section" = "true" ]; then first_section="false"; else printf ','; fi
+    file="${SECTION_FILES[$i]}"
+    homes_render_json_section "${SECTION_NAMES[$i]}" "$file"
+  done
+  printf ']}'
+  printf '\n'
+}
+
+if [ "$TEXT_MODE" = "true" ]; then
+  printf 'Homes status: %s\n' "$AGENT"
+  printf 'home: %s\n\n' "$HOME_PATH"
+fi
+
+collect_auth
+run_section "Home" check_home
+run_section "Notes" check_notes
+run_section "Modules" check_modules
+
+if [ "$TEXT_MODE" = "true" ]; then
+  print_summary
+  print_expanded_sections
+  print_next
+else
+  print_json
+fi
+
+if [ "$CHECK" = "true" ] && ! is_ready; then
+  exit 1
+fi
+exit 0

--- a/.mise/tasks/homes/status
+++ b/.mise/tasks/homes/status
@@ -34,15 +34,17 @@ if [ "$TEXT_MODE" = "true" ] && [ -t 1 ] && command -v gum >/dev/null 2>&1; then
   COLOR_MODE=true
 fi
 
-SECTION_COUNT=0
-SECTION_NAMES=()
-SECTION_FILES=()
+STATUS_GROUPS=(Auth Home Notes Modules)
 NEXT_ACTION=""
 HOME_EXISTS=false
 HOME_IS_GIT=false
+CURRENT_GROUP=""
+CURRENT_SECTION=""
 
 TMP_ROOT=$(mktemp -d)
 trap 'rm -rf "$TMP_ROOT"' EXIT
+ROWS_FILE="$TMP_ROOT/checks.tsv"
+: > "$ROWS_FILE"
 
 set_next_once() {
   local action="$1"
@@ -52,17 +54,12 @@ set_next_once() {
 }
 
 begin_section() {
-  local title="$1" out_file
-  out_file="$TMP_ROOT/section-$SECTION_COUNT.tsv"
-  : > "$out_file"
-  SECTION_NAMES+=("$title")
-  SECTION_FILES+=("$out_file")
-  SECTION_OUT="$out_file"
-  SECTION_COUNT=$((SECTION_COUNT + 1))
+  CURRENT_GROUP="$1"
+  CURRENT_SECTION="${2:-$1}"
 }
 
 record_row() {
-  homes_render_record_row "$SECTION_OUT" "$@"
+  homes_render_record_check_row "$ROWS_FILE" "$CURRENT_GROUP" "$CURRENT_SECTION" "$@"
 }
 
 record_fail() {
@@ -77,66 +74,12 @@ run_section() {
   "$check_func"
 }
 
-section_in_group() {
-  local section="$1" group="$2"
-  case "$section" in
-    "$group"|"$group: "*) return 0 ;;
-    *) return 1 ;;
-  esac
-}
-
 group_status() {
-  local group="$1" i section status result=ok found=false
-  for ((i = 0; i < ${#SECTION_NAMES[@]}; i++)); do
-    section="${SECTION_NAMES[$i]}"
-    section_in_group "$section" "$group" || continue
-    found=true
-    status=$(homes_render_file_status "${SECTION_FILES[$i]}")
-    if [ "$status" = fail ]; then
-      printf 'fail\n'
-      return 0
-    fi
-    [ "$status" = warn ] && result=warn
-  done
-  if [ "$found" != "true" ]; then
-    printf 'warn\n'
-  else
-    printf '%s\n' "$result"
-  fi
+  homes_render_check_rows_group_status "$ROWS_FILE" "$1"
 }
 
 group_first_non_ok_detail() {
-  local group="$1" i section file name status detail
-  for ((i = 0; i < ${#SECTION_NAMES[@]}; i++)); do
-    section="${SECTION_NAMES[$i]}"
-    section_in_group "$section" "$group" || continue
-    file="${SECTION_FILES[$i]}"
-    while IFS=$'\t' read -r name status detail; do
-      [ -n "$name" ] || continue
-      [ "$status" = ok ] && continue
-      if [ "$section" = "$group" ]; then
-        printf '%s: %s\n' "$name" "$detail"
-      else
-        printf '%s / %s: %s\n' "${section#$group: }" "$name" "$detail"
-      fi
-      return 0
-    done < "$file"
-  done
-  printf 'review details\n'
-}
-
-section_detail() {
-  local group="$1" label="$2" file name status detail
-  for ((i = 0; i < ${#SECTION_NAMES[@]}; i++)); do
-    [ "${SECTION_NAMES[$i]}" = "$group" ] || continue
-    file="${SECTION_FILES[$i]}"
-    while IFS=$'\t' read -r name status detail; do
-      [ "$name" = "$label" ] || continue
-      printf '%s\n' "$detail"
-      return 0
-    done < "$file"
-  done
-  return 1
+  homes_render_check_rows_first_non_ok_detail "$ROWS_FILE" "$1"
 }
 
 group_ok_detail() {
@@ -146,7 +89,7 @@ group_ok_detail() {
       printf 'ready\n'
       ;;
     Home)
-      head=$(section_detail Home HEAD || true)
+      head=$(homes_render_check_rows_detail "$ROWS_FILE" Home Home HEAD || true)
       if [ -n "$head" ]; then
         printf 'clean %s\n' "$head"
       else
@@ -157,7 +100,7 @@ group_ok_detail() {
       printf 'clean\n'
       ;;
     Modules)
-      modules=$(count_module_rows)
+      modules=$(homes_render_check_rows_count_ok_prefixed "$ROWS_FILE" Modules "module:")
       printf '%s module(s) at pin\n' "$modules"
       ;;
     *)
@@ -175,42 +118,12 @@ group_detail() {
   fi
 }
 
-section_warning_count() {
-  local file count=0
-  for file in ${SECTION_FILES[@]+"${SECTION_FILES[@]}"}; do
-    count=$((count + $(homes_render_file_warning_count "$file")))
-  done
-  printf '%s\n' "$count"
-}
-
-section_has_failures() {
-  local file
-  for file in ${SECTION_FILES[@]+"${SECTION_FILES[@]}"}; do
-    homes_render_file_has_failure "$file" && return 0
-  done
-  return 1
+warning_count() {
+  homes_render_check_rows_warning_count "$ROWS_FILE"
 }
 
 is_ready() {
-  ! section_has_failures
-}
-
-count_module_rows() {
-  local i file name status detail count=0
-  for ((i = 0; i < ${#SECTION_NAMES[@]}; i++)); do
-    [ "${SECTION_NAMES[$i]}" = "Modules" ] || continue
-    file="${SECTION_FILES[$i]}"
-    while IFS=$'\t' read -r name status detail; do
-      case "$name" in
-        module:*) [ "$status" = ok ] && count=$((count + 1)) ;;
-      esac
-    done < "$file"
-  done
-  printf '%s\n' "$count"
-}
-
-timeout_command() {
-  command -v timeout 2>/dev/null || command -v gtimeout 2>/dev/null
+  ! homes_render_check_rows_has_failure "$ROWS_FILE"
 }
 
 collect_auth() {
@@ -225,7 +138,7 @@ collect_auth() {
     return 0
   fi
 
-  if timeout_bin=$(timeout_command); then
+  if timeout_bin=$(homes_timeout_command); then
     if auth_output=$(
       cd "$ROOT" && "$timeout_bin" "$auth_timeout" mise run -q homes:auth "$AGENT" \
         --agents-root "$AGENTS_ROOT" \
@@ -274,7 +187,7 @@ collect_auth() {
   while IFS=$'\t' read -r section name status detail; do
     [ -n "$section" ] || continue
     if [ "$section" != "$current_section" ]; then
-      begin_section "Auth: $section"
+      begin_section "Auth" "$section"
       current_section="$section"
     fi
     record_row "$name" "$status" "$detail"
@@ -287,7 +200,7 @@ collect_auth() {
 }
 
 check_home() {
-  local status head branch origin
+  local state head origin
 
   if [ ! -e "$HOME_PATH" ]; then
     HOME_EXISTS=false
@@ -302,7 +215,7 @@ check_home() {
   fi
   record_row "Home path" ok "$HOME_PATH"
 
-  if ! "$GIT_BIN" -C "$HOME_PATH" rev-parse --git-dir >/dev/null 2>&1; then
+  if ! homes_git_is_repo "$HOME_PATH"; then
     HOME_IS_GIT=false
     record_fail "Git repo" "not a git repository" "clone or adopt the agent home repo"
     return 0
@@ -310,17 +223,14 @@ check_home() {
   HOME_IS_GIT=true
   record_row "Git repo" ok "present"
 
-  if head=$("$GIT_BIN" -C "$HOME_PATH" rev-parse --short HEAD 2>/dev/null); then
-    branch=$("$GIT_BIN" -C "$HOME_PATH" rev-parse --abbrev-ref HEAD 2>/dev/null || true)
-    [ -n "$branch" ] || branch="detached"
-    [ "$branch" = "HEAD" ] && branch="detached"
-    record_row "HEAD" ok "$branch @ $head"
+  if head=$(homes_git_head_label "$HOME_PATH"); then
+    record_row "HEAD" ok "$head"
   else
     record_fail "HEAD" "no commits" "finish or adopt the home bootstrap commit"
   fi
 
-  if status=$("$GIT_BIN" -C "$HOME_PATH" status --porcelain 2>/dev/null); then
-    if [ -z "$status" ]; then
+  if state=$(homes_git_worktree_state "$HOME_PATH"); then
+    if [ "$state" = "clean" ]; then
       record_row "Worktree" ok "clean"
     else
       record_fail "Worktree" "dirty; run git status --short in the home" "git -C $HOME_PATH status --short"
@@ -329,8 +239,8 @@ check_home() {
     record_fail "Worktree" "could not inspect worktree" "git -C $HOME_PATH status --short"
   fi
 
-  if origin=$("$GIT_BIN" -C "$HOME_PATH" remote get-url origin 2>/dev/null); then
-    record_row "Origin" ok "$(homes_redact_url "$origin")"
+  if origin=$(homes_git_origin_redacted "$HOME_PATH"); then
+    record_row "Origin" ok "$origin"
   else
     record_row "Origin" warn "not configured"
   fi
@@ -355,7 +265,7 @@ check_home() {
 }
 
 check_notes() {
-  local manifest notes_changes tracked_readable
+  local manifest manifest_state notes_changes tracked_readable
   manifest="$HOME_PATH/notes/.manifest"
 
   if [ "$HOME_EXISTS" != "true" ] || [ ! -d "$HOME_PATH" ]; then
@@ -369,30 +279,33 @@ check_notes() {
   fi
   record_row "Notes dir" ok "present"
 
-  if [ ! -f "$manifest" ]; then
-    record_row "Notes manifest" warn "missing notes/.manifest"
-  elif homes_file_is_gitcrypt_blob "$manifest"; then
-    record_fail "Notes manifest" "locked git-crypt blob" "cd $HOME_PATH && notes unlock"
-  else
-    record_row "Notes manifest" ok "readable"
+  manifest_state=$(homes_manifest_state "$manifest")
+  case "$manifest_state" in
+    missing)
+      record_row "Notes manifest" warn "missing notes/.manifest"
+      ;;
+    locked)
+      record_fail "Notes manifest" "locked git-crypt blob" "cd $HOME_PATH && notes unlock"
+      ;;
+    *)
+      record_row "Notes manifest" ok "readable"
 
-    if ! command -v "$NOTES_BIN" >/dev/null 2>&1; then
-      record_fail "Notes tool" "not available" "install notes or run mise install in the home"
-    elif notes_changes=$(cd "$HOME_PATH" && "$NOTES_BIN" changes --summary 2>&1); then
-      if [ "$notes_changes" = "No changes." ]; then
-        record_row "Notes changes" ok "clean"
+      if ! command -v "$NOTES_BIN" >/dev/null 2>&1; then
+        record_fail "Notes tool" "not available" "install notes or run mise install in the home"
+      elif notes_changes=$(homes_notes_changes_summary "$HOME_PATH" 2>&1); then
+        if [ "$notes_changes" = "No changes." ]; then
+          record_row "Notes changes" ok "clean"
+        else
+          record_fail "Notes changes" "pending readable note changes" "cd $HOME_PATH && notes changes --summary"
+        fi
       else
-        record_fail "Notes changes" "pending readable note changes" "cd $HOME_PATH && notes changes --summary"
+        record_fail "Notes changes" "could not inspect notes workflow" "cd $HOME_PATH && notes changes --summary"
       fi
-    else
-      record_fail "Notes changes" "could not inspect notes workflow" "cd $HOME_PATH && notes changes --summary"
-    fi
-  fi
+      ;;
+  esac
 
   if [ "$HOME_IS_GIT" = "true" ]; then
-    if ! tracked_readable=$("$GIT_BIN" -C "$HOME_PATH" ls-files 'notes/*.md' 2>/dev/null); then
-      tracked_readable=""
-    fi
+    tracked_readable=$(homes_tracked_readable_notes "$HOME_PATH")
     if [ -n "$tracked_readable" ]; then
       record_fail "Tracked readable notes" "readable notes/*.md are tracked" "cd $HOME_PATH && notes stage"
     else
@@ -402,7 +315,7 @@ check_notes() {
 }
 
 check_modules() {
-  local manifest name url pin track module_dir head any_modules=false
+  local manifest manifest_state name url pin track module_dir head any_modules=false
   manifest="$HOME_PATH/.modules/manifest"
 
   if [ "$HOME_EXISTS" != "true" ] || [ ! -d "$HOME_PATH" ]; then
@@ -410,16 +323,20 @@ check_modules() {
     return 0
   fi
 
-  if [ ! -f "$manifest" ]; then
-    record_row "Modules manifest" warn "missing .modules/manifest"
-    return 0
-  fi
-
-  if homes_file_is_gitcrypt_blob "$manifest"; then
-    record_fail "Modules manifest" "locked git-crypt blob" "cd $HOME_PATH && modules unlock"
-    return 0
-  fi
-  record_row "Modules manifest" ok "readable"
+  manifest_state=$(homes_manifest_state "$manifest")
+  case "$manifest_state" in
+    missing)
+      record_row "Modules manifest" warn "missing .modules/manifest"
+      return 0
+      ;;
+    locked)
+      record_fail "Modules manifest" "locked git-crypt blob" "cd $HOME_PATH && modules unlock"
+      return 0
+      ;;
+    *)
+      record_row "Modules manifest" ok "readable"
+      ;;
+  esac
 
   if command -v "$MODULES_BIN" >/dev/null 2>&1; then
     record_row "Modules tool" ok "available"
@@ -460,7 +377,7 @@ default_next_action() {
     printf '%s\n' "$NEXT_ACTION"
     return 0
   fi
-  warnings=$(section_warning_count)
+  warnings=$(warning_count)
   if [ "$warnings" -gt 0 ]; then
     printf 'review warnings above\n'
   else
@@ -469,44 +386,20 @@ default_next_action() {
 }
 
 print_summary() {
-  local group status detail badge
+  local group status detail summary_file
+  summary_file="$TMP_ROOT/summary.tsv"
+  : > "$summary_file"
   homes_render_heading "Summary" "$COLOR_MODE"
-  if command -v gum >/dev/null 2>&1; then
-    {
-      printf 'Section\tStatus\tDetail\n'
-      for group in Auth Home Notes Modules; do
-        status=$(group_status "$group")
-        detail=$(group_detail "$group" "$status")
-        badge=$(homes_render_status_badge "$status" "$COLOR_MODE")
-        printf '%s\t%s\t%s\n' "$group" "$badge" "$detail"
-      done
-    } | gum table --print --separator $'\t' --border rounded
-  else
-    printf 'Section\tStatus\tDetail\n'
-    for group in Auth Home Notes Modules; do
-      status=$(group_status "$group")
-      detail=$(group_detail "$group" "$status")
-      badge=$(homes_render_status_badge "$status" "$COLOR_MODE")
-      printf '%s\t%s\t%s\n' "$group" "$badge" "$detail"
-    done
-  fi
+  for group in "${STATUS_GROUPS[@]}"; do
+    status=$(group_status "$group")
+    detail=$(group_detail "$group" "$status")
+    homes_render_record_row "$summary_file" "$group" "$status" "$detail"
+  done
+  homes_render_status_table "Section" "$summary_file" "$COLOR_MODE"
 }
 
 print_expanded_sections() {
-  local group status i section printed=false
-  for group in Auth Home Notes Modules; do
-    status=$(group_status "$group")
-    [ "$status" = ok ] && continue
-    for ((i = 0; i < ${#SECTION_NAMES[@]}; i++)); do
-      section="${SECTION_NAMES[$i]}"
-      section_in_group "$section" "$group" || continue
-      printf '\n'
-      homes_render_heading "$section" "$COLOR_MODE"
-      homes_render_table "${SECTION_FILES[$i]}" "$COLOR_MODE"
-      printed=true
-    done
-  done
-  $printed || return 0
+  homes_render_check_rows_print_failed_groups "$ROWS_FILE" "$COLOR_MODE" "${STATUS_GROUPS[@]}"
 }
 
 print_next() {
@@ -517,9 +410,9 @@ print_next() {
 }
 
 print_json() {
-  local ready="true" warnings next i file first_section="true"
+  local ready="true" warnings next
   is_ready || ready="false"
-  warnings=$(section_warning_count)
+  warnings=$(warning_count)
   next=$(default_next_action)
 
   printf '{'
@@ -529,11 +422,7 @@ print_json() {
   printf ',"warnings":%s' "$warnings"
   printf ',"next":'; homes_json_string "$next"
   printf ',"sections":['
-  for ((i = 0; i < ${#SECTION_NAMES[@]}; i++)); do
-    if [ "$first_section" = "true" ]; then first_section="false"; else printf ','; fi
-    file="${SECTION_FILES[$i]}"
-    homes_render_json_section "${SECTION_NAMES[$i]}" "$file"
-  done
+  homes_render_check_rows_json_sections "$ROWS_FILE"
   printf ']}'
   printf '\n'
 }

--- a/mise.toml
+++ b/mise.toml
@@ -9,6 +9,7 @@ shiv = "https://github.com/KnickKnackLabs/vfox-shiv"
 [tools]
 usage = "3.2.1"                   # CLI arg parsing for tasks
 yq = "4.50.1"                     # YAML processing
+jq = "1.8.1"                     # JSON processing for task composition
 gh = "2.92.0"                    # GitHub API for token status tasks
 bats = "1.13.0"                  # Task test suite
 gum = "0.17.0"                   # Human-readable task tables and welcome output

--- a/test/homes_auth.bats
+++ b/test/homes_auth.bats
@@ -1,0 +1,177 @@
+#!/usr/bin/env bats
+
+bats_require_minimum_version 1.5.0
+load test_helper
+
+setup() {
+  TMPBIN="$BATS_TEST_TMPDIR/bin"
+  AGENTS_ROOT="$BATS_TEST_TMPDIR/agents"
+  FAKE_GPG_STATE="$BATS_TEST_TMPDIR/gpg-secret-imported"
+  FAKE_GH_LOG="$BATS_TEST_TMPDIR/gh.log"
+  mkdir -p "$TMPBIN" "$AGENTS_ROOT"
+  export TMPBIN AGENTS_ROOT FAKE_GPG_STATE FAKE_GH_LOG
+  export GIT_CONFIG_GLOBAL="$BATS_TEST_TMPDIR/global.gitconfig"
+  : > "$GIT_CONFIG_GLOBAL"
+  write_homes_auth_mocks
+}
+
+assert_json_output() {
+  printf '%s' "$output" | python3 -c 'import json, sys; json.load(sys.stdin)'
+}
+
+fold_task_stdout_only() {
+  fold_task "$@" 2>"$BATS_TEST_TMPDIR/stderr"
+}
+
+write_homes_auth_mocks() {
+  cat > "$TMPBIN/secrets" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "${1:-}" != "get" ]; then
+  echo "unexpected secrets command: $*" >&2
+  exit 2
+fi
+case "${2:-}" in
+  test-agent/gpg-fingerprint) echo "ABCDEF1234567890ABCDEF1234567890ABCDEF12" ;;
+  test-agent/gpg-private-key) echo "fixture-secret-material" ;;
+  test-agent/github-username) echo "test-agent-ricon" ;;
+  test-agent/github-pat) echo "fixture-github-token" ;;
+  *) echo "missing secret: ${2:-}" >&2; exit 1 ;;
+esac
+SH
+  chmod +x "$TMPBIN/secrets"
+  export SECRETS="$TMPBIN/secrets"
+
+  cat > "$TMPBIN/gpg" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+has_arg() {
+  local wanted="$1" arg
+  shift
+  for arg in "$@"; do
+    [ "$arg" = "$wanted" ] && return 0
+  done
+  return 1
+}
+if has_arg "--list-secret-keys" "$@"; then
+  if [ -f "${FAKE_GPG_STATE:?}" ]; then
+    echo "sec   rsa4096/ABCDEF1234567890"
+    exit 0
+  fi
+  exit 1
+fi
+
+echo "unexpected gpg command: $*" >&2
+exit 2
+SH
+  chmod +x "$TMPBIN/gpg"
+  export GPG="$TMPBIN/gpg"
+
+  cat > "$TMPBIN/gh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'GH_TOKEN=%s ARGS=%s\n' "${GH_TOKEN:+set}" "$*" >> "${FAKE_GH_LOG:?}"
+if [ "${1:-}" = "api" ] && { [ "${2:-}" = "user" ] || [ "${2:-}" = "/user" ]; }; then
+  if [ "${GH_TOKEN:-}" = "fixture-github-token" ]; then
+    if [ "${2:-}" = "/user" ]; then
+      printf 'HTTP/2.0 200 OK\n'
+      printf 'GitHub-Authentication-Token-Expiration: 2026-07-08 00:00:00 UTC\n'
+      printf '\n'
+      printf '{"login":"test-agent-ricon"}\n'
+    else
+      echo "test-agent-ricon"
+    fi
+    exit 0
+  fi
+  echo "Bad credentials" >&2
+  exit 1
+fi
+
+echo "unexpected gh command: $*" >&2
+exit 2
+SH
+  chmod +x "$TMPBIN/gh"
+  export GH="$TMPBIN/gh"
+}
+
+configure_ready_auth() {
+  mkdir -p "$AGENTS_ROOT/test-agent"
+  cat > "$AGENTS_ROOT/test-agent/.gitconfig" <<'GITCONFIG'
+[user]
+	name = test-agent
+	email = test-agent@ricon.family
+	signingkey = ABCDEF1234567890ABCDEF1234567890ABCDEF12
+[commit]
+	gpgsign = true
+[tag]
+	gpgsign = true
+GITCONFIG
+  touch "$FAKE_GPG_STATE"
+  git config --global --add "includeIf.gitdir:$AGENTS_ROOT/test-agent/.path" "$AGENTS_ROOT/test-agent/.gitconfig"
+}
+
+@test "homes includeIf helper preserves the existing default tilde key" {
+  run bash -c 'source "$1"; homes_agent_include_key test-agent "$HOME/agents"' _ "$REPO_DIR/.mise/lib/homes.sh"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "includeIf.gitdir:~/agents/test-agent/.path" ]
+}
+
+@test "homes:auth reports ready when local auth is configured" {
+  configure_ready_auth
+
+  run fold_task homes:auth test-agent --agents-root "$AGENTS_ROOT"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Homes auth: test-agent"* ]]
+  [[ "$output" == *"# Secrets"* ]]
+  [[ "$output" == *"# Signing"* ]]
+  [[ "$output" == *"# GitHub"* ]]
+  [[ "$output" == *"Git config"*"ok"* ]]
+  [[ "$output" == *"GitHub token"*"valid as test-agent-ricon"* ]]
+  [[ "$output" == *"expires in"* ]]
+  [[ "$output" == *"# Next"* ]]
+  [[ "$output" == *"auth ready"* ]]
+  [[ "$output" != *"fixture-github-token"* ]]
+}
+
+@test "homes:auth --json reports missing local setup without leaking token" {
+  run fold_task homes:auth test-agent --agents-root "$AGENTS_ROOT" --json
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"agent":"test-agent"'* ]]
+  [[ "$output" == *'"ready":false'* ]]
+  [[ "$output" == *'"name":"Secrets"'* ]]
+  [[ "$output" == *'"name":"Signing"'* ]]
+  [[ "$output" == *'"name":"GitHub"'* ]]
+  assert_json_output
+  [[ "$output" == *'"name":"Git config","status":"fail"'* ]]
+  [[ "$output" == *"valid as test-agent-ricon; expires in"* ]]
+  [[ "$output" == *"auth setup needed"* ]]
+  [[ "$output" != *"Homes auth:"* ]]
+  [[ "$output" != *"# Secrets"* ]]
+  [[ "$output" != *"Checking:"* ]]
+  [[ "$output" != *"fixture-github-token"* ]]
+}
+
+@test "homes:auth --json --check exits nonzero with clean JSON" {
+  run fold_task_stdout_only homes:auth test-agent --agents-root "$AGENTS_ROOT" --json --check
+
+  [ "$status" -eq 1 ]
+  assert_json_output
+  [[ "$output" == *'"ready":false'* ]]
+  [[ "$output" == *"auth setup needed"* ]]
+  [[ "$output" != *"Homes auth:"* ]]
+  [[ "$output" != *"# Secrets"* ]]
+  [[ "$output" != *"Checking:"* ]]
+  [[ "$output" != *"fixture-github-token"* ]]
+}
+
+@test "homes:auth --check exits nonzero when auth is not ready" {
+  run fold_task homes:auth test-agent --agents-root "$AGENTS_ROOT" --check
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"# Next"* ]]
+  [[ "$output" == *"auth setup needed"* ]]
+  [[ "$output" != *"fixture-github-token"* ]]
+}

--- a/test/homes_status.bats
+++ b/test/homes_status.bats
@@ -1,0 +1,278 @@
+#!/usr/bin/env bats
+
+bats_require_minimum_version 1.5.0
+load test_helper
+
+setup() {
+  TMPBIN="$BATS_TEST_TMPDIR/bin"
+  AGENTS_ROOT="$BATS_TEST_TMPDIR/agents"
+  FAKE_GPG_STATE="$BATS_TEST_TMPDIR/gpg-secret-imported"
+  FAKE_GH_LOG="$BATS_TEST_TMPDIR/gh.log"
+  mkdir -p "$TMPBIN" "$AGENTS_ROOT"
+  export TMPBIN AGENTS_ROOT FAKE_GPG_STATE FAKE_GH_LOG
+  export GIT_CONFIG_GLOBAL="$BATS_TEST_TMPDIR/global.gitconfig"
+  : > "$GIT_CONFIG_GLOBAL"
+  write_homes_status_mocks
+}
+
+assert_json_output() {
+  printf '%s' "$output" | python3 -c 'import json, sys; json.load(sys.stdin)'
+}
+
+fold_task_stdout_only() {
+  fold_task "$@" 2>"$BATS_TEST_TMPDIR/stderr"
+}
+
+write_homes_status_mocks() {
+  cat > "$TMPBIN/secrets" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "${1:-}" != "get" ]; then
+  echo "unexpected secrets command: $*" >&2
+  exit 2
+fi
+case "${2:-}" in
+  test-agent/gpg-fingerprint) echo "ABCDEF1234567890ABCDEF1234567890ABCDEF12" ;;
+  test-agent/gpg-private-key) echo "fixture-secret-material" ;;
+  test-agent/github-username) echo "test-agent-ricon" ;;
+  test-agent/github-pat) echo "fixture-github-token" ;;
+  *) echo "missing secret: ${2:-}" >&2; exit 1 ;;
+esac
+SH
+  chmod +x "$TMPBIN/secrets"
+  export SECRETS="$TMPBIN/secrets"
+
+  cat > "$TMPBIN/gpg" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+has_arg() {
+  local wanted="$1" arg
+  shift
+  for arg in "$@"; do
+    [ "$arg" = "$wanted" ] && return 0
+  done
+  return 1
+}
+if has_arg "--list-secret-keys" "$@"; then
+  if [ -f "${FAKE_GPG_STATE:?}" ]; then
+    echo "sec   rsa4096/ABCDEF1234567890"
+    exit 0
+  fi
+  exit 1
+fi
+
+echo "unexpected gpg command: $*" >&2
+exit 2
+SH
+  chmod +x "$TMPBIN/gpg"
+  export GPG="$TMPBIN/gpg"
+
+  cat > "$TMPBIN/gh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'GH_TOKEN=%s ARGS=%s\n' "${GH_TOKEN:+set}" "$*" >> "${FAKE_GH_LOG:?}"
+if [ "${1:-}" = "api" ] && { [ "${2:-}" = "user" ] || [ "${2:-}" = "/user" ]; }; then
+  if [ -n "${FAKE_GH_SLEEP:-}" ]; then
+    sleep "$FAKE_GH_SLEEP"
+  fi
+  if [ "${GH_TOKEN:-}" = "fixture-github-token" ]; then
+    if [ "${2:-}" = "/user" ]; then
+      printf 'HTTP/2.0 200 OK\n\n'
+      printf '{"login":"test-agent-ricon"}\n'
+    else
+      echo "test-agent-ricon"
+    fi
+    exit 0
+  fi
+  echo "Bad credentials" >&2
+  exit 1
+fi
+
+echo "unexpected gh command: $*" >&2
+exit 2
+SH
+  chmod +x "$TMPBIN/gh"
+  export GH="$TMPBIN/gh"
+
+  cat > "$TMPBIN/notes" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "${1:-}" = "changes" ] && [ "${2:-}" = "--summary" ]; then
+  echo "No changes."
+  exit 0
+fi
+echo "unexpected notes command: $*" >&2
+exit 2
+SH
+  chmod +x "$TMPBIN/notes"
+  export NOTES="$TMPBIN/notes"
+
+  cat > "$TMPBIN/modules" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+exit 0
+SH
+  chmod +x "$TMPBIN/modules"
+  export MODULES="$TMPBIN/modules"
+}
+
+configure_ready_auth() {
+  mkdir -p "$AGENTS_ROOT/test-agent"
+  cat > "$AGENTS_ROOT/test-agent/.gitconfig" <<'GITCONFIG'
+[user]
+	name = test-agent
+	email = test-agent@ricon.family
+	signingkey = ABCDEF1234567890ABCDEF1234567890ABCDEF12
+[commit]
+	gpgsign = true
+[tag]
+	gpgsign = true
+GITCONFIG
+  touch "$FAKE_GPG_STATE"
+  git config --global --add "includeIf.gitdir:$AGENTS_ROOT/test-agent/.path" "$AGENTS_ROOT/test-agent/.gitconfig"
+}
+
+create_module_clone() {
+  local module_dir="$1"
+  mkdir -p "$module_dir"
+  git init -q -b main "$module_dir"
+  git -C "$module_dir" config user.name "fixture"
+  git -C "$module_dir" config user.email "fixture@example.test"
+  git -C "$module_dir" config commit.gpgsign false
+  printf 'module fixture\n' > "$module_dir/README.md"
+  git -C "$module_dir" add README.md
+  git -C "$module_dir" commit -q -m "initial module"
+  git -C "$module_dir" rev-parse HEAD
+}
+
+create_ready_home() {
+  local home="$1" fold_pin den_pin
+  mkdir -p "$home/.mise/tasks/agent" "$home/notes" "$home/.modules" "$home/modules"
+  git init -q -b main "$home"
+
+  cat > "$home/AGENTS.md" <<'MD'
+# test-agent home
+MD
+  cat > "$home/mise.toml" <<'TOML'
+[settings]
+quiet = true
+
+[tools]
+"shiv:notes" = "0.8"
+"shiv:modules" = "0.9"
+TOML
+  cat > "$home/.mise/tasks/agent/prepare" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+echo prepare
+SH
+  chmod +x "$home/.mise/tasks/agent/prepare"
+  printf 'modules/\n' > "$home/.gitignore"
+  printf 'fake notes manifest\n' > "$home/notes/.manifest"
+
+  fold_pin=$(create_module_clone "$home/modules/fold")
+  den_pin=$(create_module_clone "$home/modules/den")
+  printf 'fold\thttps://github.com/ricon-family/fold.git\t%s\tmain\n' "$fold_pin" > "$home/.modules/manifest"
+  printf 'den\thttps://github.com/ricon-family/den.git\t%s\tmain\n' "$den_pin" >> "$home/.modules/manifest"
+
+  git -C "$home" remote add origin "https://github.com/test-agent/home.git"
+  git -C "$home" add AGENTS.md mise.toml .mise notes/.manifest .modules/manifest .gitignore
+  git -C "$home" \
+    -c user.name="fixture" \
+    -c user.email="fixture@example.test" \
+    -c commit.gpgsign=false \
+    commit -q -m "initial"
+}
+
+@test "homes:status reports a ready configured home" {
+  home="$BATS_TEST_TMPDIR/home"
+  create_ready_home "$home"
+  configure_ready_auth
+
+  run fold_task homes:status test-agent --agents-root "$AGENTS_ROOT" --home "$home"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Homes status: test-agent"* ]]
+  [[ "$output" == *"# Summary"* ]]
+  [[ "$output" == *"Auth"*"ready"* ]]
+  [[ "$output" == *"Home"*"clean main @"* ]]
+  [[ "$output" == *"Notes"*"clean"* ]]
+  [[ "$output" == *"Modules"*"2 module(s) at pin"* ]]
+  [[ "$output" != *"# Auth: Secrets"* ]]
+  [[ "$output" != *"module:fold"* ]]
+  [[ "$output" == *"home ready"* ]]
+  [[ "$output" != *"fixture-github-token"* ]]
+  [[ "$output" != *"fixture-secret-material"* ]]
+}
+
+@test "homes:status --json --check emits clean ready JSON" {
+  home="$BATS_TEST_TMPDIR/home"
+  create_ready_home "$home"
+  configure_ready_auth
+
+  run fold_task homes:status test-agent --agents-root "$AGENTS_ROOT" --home "$home" --json --check
+
+  [ "$status" -eq 0 ]
+  assert_json_output
+  [[ "$output" == *'"agent":"test-agent"'* ]]
+  [[ "$output" == *'"ready":true'* ]]
+  [[ "$output" == *'"name":"Auth: Secrets"'* ]]
+  [[ "$output" == *'"name":"Auth: Signing"'* ]]
+  [[ "$output" == *'"name":"Modules"'* ]]
+  [[ "$output" != *"Homes status:"* ]]
+  [[ "$output" != *"# Auth"* ]]
+  [[ "$output" != *"fixture-github-token"* ]]
+}
+
+@test "homes:status --json --check exits nonzero when auth is not ready" {
+  home="$BATS_TEST_TMPDIR/home"
+  create_ready_home "$home"
+
+  run fold_task_stdout_only homes:status test-agent --agents-root "$AGENTS_ROOT" --home "$home" --json --check
+
+  [ "$status" -eq 1 ]
+  assert_json_output
+  [[ "$output" == *'"ready":false'* ]]
+  [[ "$output" == *"auth setup needed"* ]]
+  [[ "$output" == *'"name":"Auth: Signing"'* ]]
+  [[ "$output" == *'"name":"GPG secret key","status":"fail"'* ]]
+  [[ "$output" != *"Homes status:"* ]]
+  [[ "$output" != *"# Auth"* ]]
+  [[ "$output" != *"fixture-github-token"* ]]
+  [[ "$output" != *"fixture-secret-material"* ]]
+}
+
+@test "homes:status points missing homes at adopt-remote when auth is ready" {
+  configure_ready_auth
+
+  run fold_task_stdout_only homes:status test-agent \
+    --agents-root "$AGENTS_ROOT" \
+    --home "$BATS_TEST_TMPDIR/missing-home" \
+    --json \
+    --check
+
+  [ "$status" -eq 1 ]
+  assert_json_output
+  [[ "$output" == *'"ready":false'* ]]
+  [[ "$output" == *'"name":"Home path","status":"fail"'* ]]
+  [[ "$output" == *"homes:adopt-remote test-agent"* ]]
+  [[ "$output" != *"fixture-github-token"* ]]
+}
+
+@test "homes:status reports auth timeout instead of hanging" {
+  command -v timeout >/dev/null 2>&1 || command -v gtimeout >/dev/null 2>&1 || skip "timeout/gtimeout command unavailable"
+  home="$BATS_TEST_TMPDIR/home"
+  create_ready_home "$home"
+  configure_ready_auth
+  export FAKE_GH_SLEEP=5
+  export HOMES_STATUS_AUTH_TIMEOUT=1
+
+  run fold_task_stdout_only homes:status test-agent --agents-root "$AGENTS_ROOT" --home "$home" --json --check
+
+  [ "$status" -eq 1 ]
+  assert_json_output
+  [[ "$output" == *'"ready":false'* ]]
+  [[ "$output" == *'"name":"homes:auth","status":"fail","detail":"timed out after 1s"'* ]]
+  [[ "$output" == *"mise run homes:auth test-agent"* ]]
+  [[ "$output" != *"fixture-github-token"* ]]
+}


### PR DESCRIPTION
## Summary

Draft read-only Phase 1 surface for existing agent-home bootstrap:

- add `homes:auth` read-only auth/signing/GitHub readiness with JSON/check modes;
- add `homes:status` aggregate readiness with summary-first human output and full-detail JSON;
- keep happy-path human status compact while expanding warn/fail sections;
- compose `homes:status` with the public `mise run homes:auth --json --check` path and parse stdout with declared `jq`;
- use a small TSV render helper for shared row/table/status/JSON-section output without moving domain checks into a framework;
- add bounded auth subprocess handling via `timeout`/`gtimeout` when available;
- add BATS coverage for no PAT/private-key leakage, clean JSON, `--check`, status summary behavior, existing `~/agents/<agent>` includeIf keys, and auth timeout handling.

## Notes

This PR is now read-only only. `homes:auth:setup` has been split out for follow-up Phase 2 work.

Unrelated fold note edits in the working tree were intentionally left out.

## Validation

- `bash -n .mise/lib/homes.sh .mise/lib/homes_render.sh .mise/tasks/homes/auth/_default .mise/tasks/homes/status test/homes_auth.bats test/homes_status.bats`
- `mise run test homes_auth homes_status`
- `mise run test`
- `git pre-commit`
- `git pre-push` before force-push reported the expected ahead/behind failure caused by amending this draft branch; push used `--force-with-lease`.
