### PR TITLE
agent: avoid pi auth type value output

### DIFF
--- a/.mise/tasks/agent/desk/pi-auth
+++ b/.mise/tasks/agent/desk/pi-auth
@@ -50,7 +50,8 @@ print_auth_entries() {
         (.value | keys) as $keys
         | ($keys | map(select(test($sensitive; "i") | not)) | sort | @json) as $safe
         | ($keys | map(select(test($sensitive; "i"))) | sort | @json) as $redacted
-        | "    \(.key): type=\(.value.type // "?") safe_keys=\($safe) redacted_keys=\($redacted)"
+        | (if ($keys | index("type")) then "present" else "missing" end) as $type_key
+        | "    \(.key): type_key=\($type_key) safe_keys=\($safe) redacted_keys=\($redacted)"
       else
         "    \(.key): value_type=\(.value | type)"
       end

--- a/test/agent_desk.bats
+++ b/test/agent_desk.bats
@@ -78,7 +78,7 @@ make_repo() {
   cat > "$pi_dir/auth.json" <<'JSON'
 {
   "openai-codex": {
-    "type": "oauth",
+    "type": "SECRET_TYPE_VALUE",
     "access_token": "SECRET_ACCESS",
     "refresh": "SECRET_REFRESH",
     "accountId": "acct_123",
@@ -103,6 +103,8 @@ JSON
   [[ "$output" != *"SECRET_ACCESS"* ]]
   [[ "$output" != *"SECRET_REFRESH"* ]]
   [[ "$output" != *"SECRET_KEY"* ]]
+  [[ "$output" != *"SECRET_TYPE_VALUE"* ]]
+  [[ "$output" == *"type_key=present"* ]]
 }
 
 @test "agent:desk:smoke can fail closed when --check is set" {


### PR DESCRIPTION
Fix-it for fold#113.

`agent:desk:pi-auth` promised not to print secret values, but it still printed the raw `type` field value from `auth.json`. That is usually benign metadata, but it is still a value from an auth file and malformed/unexpected auth JSON could put secret material there.

This changes the output to report whether a `type` key is present without printing its value, and extends the BATS fixture to prove a secret-looking `type` value is not emitted.

Validation:

- `bash -n .mise/tasks/agent/desk/pi-auth`
- `mise run -q test agent_desk`
- `mise run -q test`
