### PR TITLE
agent: resolve wake packet path before launch

### DIFF
--- a/.mise/lib/agent_desk.sh
+++ b/.mise/lib/agent_desk.sh
@@ -30,6 +30,20 @@ agent_desk_abs_path() {
   (cd "$path" && pwd -P)
 }
 
+agent_desk_abs_file() {
+  local path="$1" dir base
+  if [ -z "$path" ]; then
+    return 1
+  fi
+  if [ ! -f "$path" ]; then
+    echo "ERROR: file does not exist: $path" >&2
+    exit 1
+  fi
+  dir=$(dirname "$path")
+  base=$(basename "$path")
+  printf '%s/%s\n' "$(cd "$dir" && pwd -P)" "$base"
+}
+
 agent_desk_find_from_cwd() {
   local dir="$PWD"
   while [ "$dir" != "/" ]; do

--- a/.mise/tasks/agent/desk/wake
+++ b/.mise/tasks/agent/desk/wake
@@ -44,6 +44,7 @@ if [ ! -f "$PACKET_PATH" ]; then
   echo "ERROR: packet file not found: $PACKET_PATH" >&2
   exit 1
 fi
+PACKET_PATH=$(agent_desk_abs_file "$PACKET_PATH")
 IDENTITY_SOURCE=$(agent_desk_abs_path "$IDENTITY_SOURCE")
 
 if [ -z "$WORK_DIR" ]; then

--- a/test/agent_desk.bats
+++ b/test/agent_desk.bats
@@ -136,6 +136,18 @@ JSON
   grep -q 'shimmer as "$AGENT"' "$work_dir/start-quick-a.sh"
 }
 
+@test "agent:desk:wake renders relative packet paths as absolute for the launcher" {
+  home="$BATS_TEST_TMPDIR/home"
+  work_dir="$BATS_TEST_TMPDIR/wake"
+  make_repo "$home" home
+  repo_real=$(cd "$REPO_DIR" && pwd -P)
+
+  run fold_task agent:desk:wake quick --home "$home" --shell quick-a --packet AGENTS.md --work-dir "$work_dir"
+
+  [ "$status" -eq 0 ]
+  grep -q "PACKET_PATH='$repo_real/AGENTS.md'" "$work_dir/start-quick-a.sh"
+}
+
 @test "agent:desk:wake --yes launches shell and smokes it" {
   home="$BATS_TEST_TMPDIR/home"
   work_dir="$BATS_TEST_TMPDIR/wake"


### PR DESCRIPTION
Fix-it for fold#113.

`agent:desk:wake` validates `--packet` before rendering the launcher, but the launcher `cd`s into the target home before reading the packet. If the packet was passed as a relative path, dry-run succeeded and the launched shell would later fail to read it from the home directory.

This resolves packet paths to absolute paths before writing the launcher and adds a regression test using a relative packet argument.

Validation:

- `git diff --check`
- `bash -n .mise/lib/agent_desk.sh .mise/tasks/agent/desk/wake test/agent_desk.bats`
- `mise run -q test agent_desk`
- `mise run -q test`
