### PR TITLE
workflows: wake CI agents from home

### DIFF
--- a/.github/workflows/agent-run.yml
+++ b/.github/workflows/agent-run.yml
@@ -50,29 +50,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
-      REPO_NAME: ${{ github.event.repository.name }}
       AGENT_HOME: /home/runner/agents/${{ inputs.agent }}/home
-      CALLER_REPO: ${{ github.repository }}
-      CALLER_REPO_PATH: /home/runner/agents/${{ inputs.agent }}/caller/${{ github.event.repository.name }}
+      DISPATCH_REPO: ${{ github.repository }}
       GH_TOKEN: ${{ secrets.AGENT_GITHUB_PAT }}
       # Nested shiv package installs run their own mise commands.
       MISE_EXPERIMENTAL: "1"
-    defaults:
-      run:
-        working-directory: /home/runner/agents/${{ inputs.agent }}/caller/${{ github.event.repository.name }}
     steps:
-      - name: Checkout current repo
-        uses: actions/checkout@v6
-        with:
-          token: ${{ secrets.AGENT_GITHUB_PAT }}
-          path: repo
-
-      - name: Setup workspace
-        working-directory: ${{ github.workspace }}
-        run: |
-          mkdir -p "$(dirname "$CALLER_REPO_PATH")"
-          mv repo "$CALLER_REPO_PATH"
-
       - name: Resolve mise version
         id: mise-version
         run: |
@@ -89,44 +72,9 @@ jobs:
         uses: jdx/mise-action@v4
         with:
           version: ${{ steps.mise-version.outputs.version }}
-          install: true
+          install: false
         env:
           GITHUB_TOKEN: ${{ secrets.AGENT_GITHUB_PAT }}
-
-      - name: Install project tools
-        env:
-          MISE_JOBS: 1  # Serialize — vfox-shiv bootstrap isn't parallel-safe yet
-        run: |
-          mise trust
-          mise install
-
-      - name: Trust shiv package configs
-        run: |
-          while IFS= read -r -d '' config; do
-            mise trust -q "$config"
-          done < <(find "$HOME/.local/share/mise/installs" -path '*/packages/*/mise.toml' -print0)
-
-      - name: Compute sessions CLI cache key
-        id: sessions
-        run: |
-          SESSIONS_DIR="$(mise where shiv:sessions)/packages/sessions"
-          echo "mix-lock-hash=$(sha256sum "$SESSIONS_DIR/cli/mix.lock" | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
-
-      - name: Cache sessions CLI build
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.local/share/mise/installs/shiv-sessions/*/packages/sessions/cli/_build
-            ~/.local/share/mise/installs/shiv-sessions/*/packages/sessions/cli/deps
-          key: ${{ runner.os }}-sessions-cli-${{ steps.sessions.outputs.mix-lock-hash }}
-          restore-keys: |
-            ${{ runner.os }}-sessions-cli-
-
-      - name: Build sessions CLI
-        run: sessions cli:build
-
-      - name: Install pi
-        run: mise use -g github:badlogic/pi-mono@0.73.0
 
       - name: Setup secrets for env provider
         env:
@@ -167,14 +115,6 @@ jobs:
 
           echo "SECRETS_PROVIDER=env" >> "$GITHUB_ENV"
 
-      - name: Setup GPG
-        run: shimmer gpg:setup ${{ inputs.agent }}
-
-      - name: Setup email
-        env:
-          EMAIL_PASSWORD: ${{ secrets.AGENT_EMAIL_PASSWORD }}
-        run: emails setup ${{ inputs.agent }}
-
       - name: Resolve agent GitHub login
         run: |
           set -euo pipefail
@@ -207,34 +147,69 @@ jobs:
           git clone "https://x-access-token:${GH_TOKEN}@github.com/${HOME_REPO}.git" "$HOME_DIR"
           echo "Home repo available at $HOME_DIR"
 
+      - name: Install home tools
+        working-directory: /home/runner/agents/${{ inputs.agent }}/home
+        env:
+          MISE_JOBS: 1  # Serialize — vfox-shiv bootstrap isn't parallel-safe yet
+        run: |
+          gh auth setup-git
+          mise trust
+          mise install
+
+      - name: Trust shiv package configs
+        working-directory: /home/runner/agents/${{ inputs.agent }}/home
+        run: |
+          while IFS= read -r -d '' config; do
+            mise trust -q "$config"
+          done < <(find "$HOME/.local/share/mise/installs" -path '*/packages/*/mise.toml' -print0)
+
+      - name: Compute sessions CLI cache key
+        id: sessions
+        working-directory: /home/runner/agents/${{ inputs.agent }}/home
+        run: |
+          SESSIONS_DIR="$(mise where shiv:sessions)/packages/sessions"
+          echo "mix-lock-hash=$(sha256sum "$SESSIONS_DIR/cli/mix.lock" | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache sessions CLI build
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.local/share/mise/installs/shiv-sessions/*/packages/sessions/cli/_build
+            ~/.local/share/mise/installs/shiv-sessions/*/packages/sessions/cli/deps
+          key: ${{ runner.os }}-sessions-cli-${{ steps.sessions.outputs.mix-lock-hash }}
+          restore-keys: |
+            ${{ runner.os }}-sessions-cli-
+
+      - name: Build sessions CLI
+        working-directory: /home/runner/agents/${{ inputs.agent }}/home
+        run: sessions cli:build
+
+      - name: Install pi
+        working-directory: /home/runner/agents/${{ inputs.agent }}/home
+        run: mise use -g github:badlogic/pi-mono@0.73.0
+
+      - name: Setup GPG
+        working-directory: /home/runner/agents/${{ inputs.agent }}/home
+        run: shimmer gpg:setup ${{ inputs.agent }}
+
+      - name: Setup email
+        working-directory: /home/runner/agents/${{ inputs.agent }}/home
+        env:
+          EMAIL_PASSWORD: ${{ secrets.AGENT_EMAIL_PASSWORD }}
+        run: emails setup ${{ inputs.agent }}
+
       - name: Prepare home repo
+        working-directory: /home/runner/agents/${{ inputs.agent }}/home
         env:
           MISE_JOBS: 1
         run: |
           set -euo pipefail
 
-          HOME_DIR="$AGENT_HOME"
-          if [ ! -d "$HOME_DIR/.git" ]; then
-            echo "Home repo not present at $HOME_DIR; skipping home preparation"
-            exit 0
-          fi
-
-          cd "$HOME_DIR"
           gh auth setup-git
-          mise trust
-          mise install
-
           if mise tasks info agent:prepare >/dev/null 2>&1; then
             mise run agent:prepare
           else
             echo "::warning::No agent:prepare task found in home repo; skipping home-specific preparation. Add an agent:prepare task to silence this warning."
-          fi
-
-      - name: Unlock caller repo notes
-        run: |
-          if [ -d ".git-crypt" ]; then
-            rudi install
-            notes unlock || echo "Warning: notes unlock failed — encrypted files may not be readable"
           fi
 
       - name: Setup pi auth
@@ -298,6 +273,7 @@ jobs:
 
       - name: Back up sessions
         if: always()
+        working-directory: /home/runner/agents/${{ inputs.agent }}/home
         env:
           AGENT: ${{ inputs.agent }}
         run: |
@@ -318,7 +294,7 @@ jobs:
           echo ""
           echo "--- Disk usage ---"
           df -h / | tail -1
-          du -sh "$CALLER_REPO_PATH" 2>/dev/null || true
+          du -sh "$AGENT_HOME" 2>/dev/null || true
           du -sh "$HOME/agents" 2>/dev/null || true
           echo ""
           echo "--- mise status ---"

--- a/.github/workflows/agent-run.yml
+++ b/.github/workflows/agent-run.yml
@@ -273,10 +273,15 @@ jobs:
 
       - name: Back up sessions
         if: always()
-        working-directory: /home/runner/agents/${{ inputs.agent }}/home
         env:
           AGENT: ${{ inputs.agent }}
         run: |
+          if [ ! -d "$AGENT_HOME" ]; then
+            echo "Agent home not available; skipping session backup"
+            exit 0
+          fi
+
+          cd "$AGENT_HOME"
           if ! command -v shimmer >/dev/null 2>&1; then
             echo "shimmer not available; skipping session backup"
             exit 0

--- a/.github/workflows/agent-run.yml
+++ b/.github/workflows/agent-run.yml
@@ -51,13 +51,15 @@ jobs:
     timeout-minutes: 20
     env:
       REPO_NAME: ${{ github.event.repository.name }}
-      WORK_DIR: /home/runner/agents/${{ inputs.agent }}/${{ github.event.repository.name }}
+      AGENT_HOME: /home/runner/agents/${{ inputs.agent }}/home
+      CALLER_REPO: ${{ github.repository }}
+      CALLER_REPO_PATH: /home/runner/agents/${{ inputs.agent }}/caller/${{ github.event.repository.name }}
       GH_TOKEN: ${{ secrets.AGENT_GITHUB_PAT }}
       # Nested shiv package installs run their own mise commands.
       MISE_EXPERIMENTAL: "1"
     defaults:
       run:
-        working-directory: /home/runner/agents/${{ inputs.agent }}/${{ github.event.repository.name }}
+        working-directory: /home/runner/agents/${{ inputs.agent }}/caller/${{ github.event.repository.name }}
     steps:
       - name: Checkout current repo
         uses: actions/checkout@v6
@@ -68,8 +70,8 @@ jobs:
       - name: Setup workspace
         working-directory: ${{ github.workspace }}
         run: |
-          mkdir -p "$(dirname "$WORK_DIR")"
-          mv repo "$WORK_DIR"
+          mkdir -p "$(dirname "$CALLER_REPO_PATH")"
+          mv repo "$CALLER_REPO_PATH"
 
       - name: Resolve mise version
         id: mise-version
@@ -173,19 +175,26 @@ jobs:
           EMAIL_PASSWORD: ${{ secrets.AGENT_EMAIL_PASSWORD }}
         run: emails setup ${{ inputs.agent }}
 
+      - name: Resolve agent GitHub login
+        run: |
+          set -euo pipefail
+          login=$(gh api user --jq .login)
+          if [[ -z "$login" || ! "$login" =~ ^[A-Za-z0-9]([A-Za-z0-9-]{0,37}[A-Za-z0-9])?$ ]]; then
+            echo "::error::Could not resolve a valid GitHub login from the agent token"
+            exit 1
+          fi
+          echo "AGENT_GITHUB_LOGIN=$login" >> "$GITHUB_ENV"
+          echo "BROWSER_GITHUB_COM_USERNAME=$login" >> "$GITHUB_ENV"
+          echo "Agent GitHub login: $login"
+
       - name: Clone home repo
         run: |
-          HOME_DIR="$HOME/agents/${{ inputs.agent }}/home"
-          HOME_REPO="${{ inputs.agent }}-ricon/home"
-          LEGACY_REPO="${{ inputs.agent }}-ricon/zettelkasten"
+          HOME_DIR="$AGENT_HOME"
+          HOME_REPO="$AGENT_GITHUB_LOGIN/home"
 
-          if gh repo view "$HOME_REPO" --json name > /dev/null 2>&1; then
-            REPO="$HOME_REPO"
-          elif gh repo view "$LEGACY_REPO" --json name > /dev/null 2>&1; then
-            REPO="$LEGACY_REPO"
-          else
-            echo "No home repo found for ${{ inputs.agent }}, skipping"
-            exit 0
+          if ! gh repo view "$HOME_REPO" --json name > /dev/null 2>&1; then
+            echo "::error::No home repo found for $AGENT_GITHUB_LOGIN at $HOME_REPO"
+            exit 1
           fi
 
           if [ -d "$HOME_DIR/.git" ]; then
@@ -193,9 +202,9 @@ jobs:
             exit 0
           fi
 
-          echo "Cloning home repo from $REPO..."
+          echo "Cloning home repo from $HOME_REPO..."
           mkdir -p "$(dirname "$HOME_DIR")"
-          git clone "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" "$HOME_DIR"
+          git clone "https://x-access-token:${GH_TOKEN}@github.com/${HOME_REPO}.git" "$HOME_DIR"
           echo "Home repo available at $HOME_DIR"
 
       - name: Prepare home repo
@@ -204,7 +213,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          HOME_DIR="$HOME/agents/${{ inputs.agent }}/home"
+          HOME_DIR="$AGENT_HOME"
           if [ ! -d "$HOME_DIR/.git" ]; then
             echo "Home repo not present at $HOME_DIR; skipping home preparation"
             exit 0
@@ -248,12 +257,12 @@ jobs:
           echo "PI_CODING_AGENT_DIR=$PI_AGENT_DIR" >> "$GITHUB_ENV"
 
       - name: Run agent
+        working-directory: /home/runner/agents/${{ inputs.agent }}/home
         env:
           AGENT: ${{ inputs.agent }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           BROWSER_GITHUB_COM_PASSWORD: ${{ secrets.AGENT_GITHUB_PASSWORD }}
-          BROWSER_GITHUB_COM_USERNAME: ${{ inputs.agent }}-ricon
           DISPATCH_CONTEXT: ${{ github.triggering_actor }}
           INPUT_MESSAGE: ${{ inputs.message }}
           INPUT_MODEL: ${{ inputs.model }}
@@ -263,8 +272,8 @@ jobs:
 
           echo "Working directory: $(pwd)"
 
-          # shimmer as sets identity env vars (AGENT_IDENTITY, GIT_AUTHOR_*, GH_TOKEN, etc.)
-          # shimmer agent --headless delegates to sessions run for execution
+          # shimmer as sets selected-agent env vars (GIT_AUTHOR_*, GH_TOKEN, etc.)
+          # shimmer agent --headless delegates to sessions wake for execution
           eval "$(shimmer as "$AGENT")"
 
           # Configure gh as git credential helper so shiv can clone private repos
@@ -309,7 +318,7 @@ jobs:
           echo ""
           echo "--- Disk usage ---"
           df -h / | tail -1
-          du -sh "$WORK_DIR" 2>/dev/null || true
+          du -sh "$CALLER_REPO_PATH" 2>/dev/null || true
           du -sh "$HOME/agents" 2>/dev/null || true
           echo ""
           echo "--- mise status ---"


### PR DESCRIPTION
## Summary

- updates generated `agent-run.yml` so CI wakes clone only the agent home repo and run from `~/agents/<agent>/home`
- removes the dispatch/triggering repo checkout entirely; the triggering repo is metadata via `DISPATCH_REPO`, not a workspace
- installs tools from the cloned home repo before running `agent:prepare`
- resolves the agent GitHub login from the CI token and clones `<login>/home`, removing hard-coded `-ricon` / legacy-home assumptions
- keeps session backup best-effort if the home clone failed before `AGENT_HOME` exists

## Dependency

Generated from local `KnickKnackLabs/shimmer#790` source-template changes.

This is the fold-side generated workflow update for `ricon-family/fold#117`. It should not merge ahead of the shimmer source change unless Or explicitly chooses that ordering.

## Validation

- `mise run test` — 82/82 BATS, codebase lint, welcome smoke

## Notes

`shimmer workflows:generate --check` against fold main is currently blocked by `ricon-family/fold#98`: fold main does not yet implement the `agent:list --ci --json` metadata required by current shimmer mention-wake generation.
