### PR TITLE
workflows: let sessions own CLI readiness

### DIFF
--- a/.github/workflows/agent-run.yml
+++ b/.github/workflows/agent-run.yml
@@ -180,10 +180,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-sessions-cli-
 
-      - name: Build sessions CLI
-        working-directory: /home/runner/agents/${{ inputs.agent }}/home
-        run: sessions cli:build
-
       - name: Install pi
         working-directory: /home/runner/agents/${{ inputs.agent }}/home
         run: mise use -g github:badlogic/pi-mono@0.73.0


### PR DESCRIPTION
## Summary

- Regenerates `agent-run.yml` from `KnickKnackLabs/shimmer#791`.
- Removes the eager `sessions cli:build` step from generated agent CI wakes.
- Keeps the sessions cache restore path; the actual CLI readiness remains owned by `shimmer agent --headless` / `sessions`.

## Why

A `fold#117` Junior CI smoke (`run 27885008661`) cloned Junior's home correctly to `/home/runner/agents/junior/home`, then failed before the agent ran because the workflow invoked a bare `sessions cli:build` from the home context:

```text
mise ERROR No version is set for shim: sessions
```

That is a workflow/template leak. The generated wake should launch from the home repo and let shimmer/sessions own execution readiness.

Depends on: KnickKnackLabs/shimmer#791.
Follow-up for sessions-side polish: KnickKnackLabs/sessions#111.

## Validation

- `PROJECT_DIR=$PWD mise -C /Users/rikonor/agents/junior/shimmer run -q workflows:generate --check`
- `mise run test` — 88/88 plus codebase lint and welcome smoke
- `git diff --check`
