### PR TITLE
agent:smoke: add home readiness baseline

### DIFF
--- a/.mise/tasks/agent/smoke
+++ b/.mise/tasks/agent/smoke
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+#MISE description="Smoke-check an agent home after preparation"
+#USAGE flag "--home <path>" required=#true help="Prepared agent home path to check"
+#USAGE example "mise run agent:smoke -- --home ~/agents/c0da/home" header="Check one prepared home"
+set -euo pipefail
+
+HOME_DIR="${usage_home:?home required}"
+NOTES_BIN="${NOTES:-notes}"
+JQ_BIN="${JQ:-jq}"
+
+failures=0
+
+row() {
+  local check="$1" status="$2" detail="$3"
+  printf '%s\t%s\t%s\n' "$check" "$status" "$detail"
+  if [ "$status" = "FAIL" ]; then
+    failures=$((failures + 1))
+  fi
+}
+
+is_git_repo() {
+  git -C "$1" rev-parse --is-inside-work-tree >/dev/null 2>&1
+}
+
+manifest_readable() {
+  local manifest="$1"
+  [ -f "$manifest" ] || return 1
+  LC_ALL=C awk '
+    NF == 0 { next }
+    NF != 3 && NF != 4 { bad = 1 }
+    $3 !~ /^[0-9a-f]{40}$/ { bad = 1 }
+    END { exit bad }
+  ' "$manifest" 2>/dev/null
+}
+
+check_notes_repo() {
+  local label="$1" dir="$2" status encryption obfuscation
+
+  if [ ! -f "$dir/notes/.manifest" ]; then
+    row "$label notes" OK "not notes-managed"
+    return 0
+  fi
+
+  if ! status=$(cd "$dir" && "$NOTES_BIN" status --json 2>/dev/null); then
+    row "$label notes" FAIL "notes status failed"
+    return 0
+  fi
+
+  encryption=$(printf '%s' "$status" | "$JQ_BIN" -r '.encryption.status // ""')
+  obfuscation=$(printf '%s' "$status" | "$JQ_BIN" -r '.obfuscation.status // ""')
+  if [ "$encryption" = "unlocked" ] && [ "$obfuscation" = "deobfuscated" ]; then
+    row "$label notes" OK "unlocked/deobfuscated"
+  else
+    row "$label notes" FAIL "${encryption:-?}/${obfuscation:-?}"
+  fi
+}
+
+check_notes_hooks() {
+  local label="$1" dir="$2" missing=""
+
+  if [ ! -f "$dir/notes/.manifest" ]; then
+    row "$label notes hooks" OK "not notes-managed"
+    return 0
+  fi
+
+  [ -f "$dir/.git/hooks/pre-commit" ] || missing="${missing} pre-commit"
+  [ -f "$dir/.git/hooks/post-checkout" ] || missing="${missing} post-checkout"
+  if [ -z "$missing" ]; then
+    row "$label notes hooks" OK "pre-commit and post-checkout present"
+  else
+    row "$label notes hooks" FAIL "missing:${missing}"
+  fi
+}
+
+check_required_modules() {
+  local modules_raw="${AGENT_PREPARE_MODULES:-}" module missing=""
+
+  if [ -z "$modules_raw" ]; then
+    row "required modules" OK "none declared"
+    return 0
+  fi
+
+  while IFS= read -r module; do
+    [ -n "$module" ] || continue
+    [ -d "$HOME_DIR/modules/$module/.git" ] || missing="${missing} $module"
+  done < <(printf '%s' "$modules_raw" | xargs printf '%s\n')
+
+  if [ -z "$missing" ]; then
+    row "required modules" OK "$modules_raw"
+  else
+    row "required modules" FAIL "missing:${missing}"
+  fi
+}
+
+if [ ! -d "$HOME_DIR" ]; then
+  row "home path" FAIL "missing: $HOME_DIR"
+else
+  row "home path" OK "$HOME_DIR"
+fi
+
+if [ -d "$HOME_DIR" ] && is_git_repo "$HOME_DIR"; then
+  row "home git" OK "git repo"
+else
+  row "home git" FAIL "not a git repo"
+fi
+
+if [ -x "$HOME_DIR/.mise/tasks/agent/prepare" ]; then
+  row "agent:prepare" OK "present"
+else
+  row "agent:prepare" FAIL "missing or not executable"
+fi
+
+check_notes_repo "home" "$HOME_DIR"
+check_notes_hooks "home" "$HOME_DIR"
+
+if [ -f "$HOME_DIR/.modules/config" ]; then
+  if manifest_readable "$HOME_DIR/.modules/manifest"; then
+    row "home modules manifest" OK "readable"
+  else
+    row "home modules manifest" FAIL "missing or encrypted"
+  fi
+else
+  row "home modules manifest" OK "no modules config"
+fi
+
+check_required_modules
+
+for module in den fold; do
+  module_dir="$HOME_DIR/modules/$module"
+  if [ -d "$module_dir/.git" ]; then
+    row "module:$module clone" OK "present"
+    check_notes_repo "module:$module" "$module_dir"
+    check_notes_hooks "module:$module" "$module_dir"
+  else
+    row "module:$module clone" OK "not present"
+  fi
+done
+
+if [ "$failures" -ne 0 ]; then
+  exit 1
+fi

--- a/test/agent_smoke.bats
+++ b/test/agent_smoke.bats
@@ -1,0 +1,136 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  TEST_TMPDIR=$(mktemp -d)
+  export TEST_TMPDIR
+  MOCK_NOTES="$TEST_TMPDIR/notes"
+  cat > "$MOCK_NOTES" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "${1:-}" = "status" ] && [ "${2:-}" = "--json" ]; then
+  case "$PWD" in
+    *locked*) printf '{"encryption":{"status":"locked"},"obfuscation":{"status":"unknown"}}\n' ;;
+    *) printf '{"encryption":{"status":"unlocked"},"obfuscation":{"status":"deobfuscated"}}\n' ;;
+  esac
+  exit 0
+fi
+echo "unexpected notes command: $*" >&2
+exit 2
+SH
+  chmod +x "$MOCK_NOTES"
+  export NOTES="$MOCK_NOTES"
+}
+
+teardown() {
+  rm -rf "$TEST_TMPDIR"
+}
+
+make_git_repo() {
+  local dir="$1"
+  mkdir -p "$dir"
+  git -C "$dir" init -q -b main
+}
+
+add_prepare_task() {
+  local dir="$1"
+  mkdir -p "$dir/.mise/tasks/agent"
+  cat > "$dir/.mise/tasks/agent/prepare" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+SH
+  chmod +x "$dir/.mise/tasks/agent/prepare"
+}
+
+add_notes_ready() {
+  local dir="$1"
+  mkdir -p "$dir/notes" "$dir/.git/hooks"
+  touch "$dir/notes/.manifest" "$dir/.git/hooks/pre-commit" "$dir/.git/hooks/post-checkout"
+}
+
+add_modules_manifest() {
+  local dir="$1"
+  mkdir -p "$dir/.modules"
+  touch "$dir/.modules/config"
+  cat > "$dir/.modules/manifest" <<'EOF'
+den	https://github.com/ricon-family/den.git	0123456789abcdef0123456789abcdef01234567	main
+fold	https://github.com/ricon-family/fold.git	abcdef0123456789abcdef0123456789abcdef01	main
+EOF
+}
+
+add_module_clone() {
+  local home="$1" module="$2"
+  local dir="$home/modules/$module"
+  make_git_repo "$dir"
+  add_notes_ready "$dir"
+}
+
+@test "agent:smoke passes for a prepared home with required modules" {
+  home="$TEST_TMPDIR/home"
+  make_git_repo "$home"
+  add_prepare_task "$home"
+  add_notes_ready "$home"
+  add_modules_manifest "$home"
+  add_module_clone "$home" den
+  add_module_clone "$home" fold
+
+  run env AGENT_PREPARE_MODULES="den fold" bash -c 'fold_task agent:smoke --home "$1"' _ "$home"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *$'home notes\tOK\tunlocked/deobfuscated'* ]]
+  [[ "$output" == *$'required modules\tOK\tden fold'* ]]
+  [[ "$output" == *$'module:fold notes\tOK\tunlocked/deobfuscated'* ]]
+}
+
+@test "agent:smoke fails when notes-managed home is locked" {
+  home="$TEST_TMPDIR/locked-home"
+  make_git_repo "$home"
+  add_prepare_task "$home"
+  add_notes_ready "$home"
+
+  run fold_task agent:smoke --home "$home"
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *$'home notes\tFAIL\tlocked/unknown'* ]]
+}
+
+@test "agent:smoke fails when required modules are missing" {
+  home="$TEST_TMPDIR/home"
+  make_git_repo "$home"
+  add_prepare_task "$home"
+  add_modules_manifest "$home"
+  add_module_clone "$home" den
+
+  run env AGENT_PREPARE_MODULES="den fold" bash -c 'fold_task agent:smoke --home "$1"' _ "$home"
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *$'required modules\tFAIL\tmissing: fold'* ]]
+}
+
+@test "agent:smoke fails when notes hooks are missing" {
+  home="$TEST_TMPDIR/home"
+  make_git_repo "$home"
+  add_prepare_task "$home"
+  mkdir -p "$home/notes"
+  touch "$home/notes/.manifest"
+
+  run fold_task agent:smoke --home "$home"
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *$'home notes hooks\tFAIL\tmissing: pre-commit post-checkout'* ]]
+}
+
+@test "agent:smoke fails when module manifest is encrypted" {
+  home="$TEST_TMPDIR/home"
+  make_git_repo "$home"
+  add_prepare_task "$home"
+  mkdir -p "$home/.modules"
+  touch "$home/.modules/config"
+  printf 'GITCRYPT' > "$home/.modules/manifest"
+
+  run fold_task agent:smoke --home "$home"
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *$'home modules manifest\tFAIL\tmissing or encrypted'* ]]
+}


### PR DESCRIPTION
## Summary

Adds a shared fold `agent:smoke` task that checks an already-prepared agent home for wakeability/readiness postconditions.

The contract is intentionally separate from `agent:prepare`:

- `agent:prepare` mutates setup.
- `agent:smoke` verifies readiness after setup.

## Checks

`mise run agent:smoke -- --home <home>` reports TSV rows and exits nonzero on required failures:

- home path and Git repo
- executable home `agent:prepare`
- notes status unlocked/deobfuscated when `notes/.manifest` exists
- notes hooks (`pre-commit`, `post-checkout`) for notes-managed repos
- readable `.modules/manifest` when `.modules/config` exists
- modules declared by `AGENT_PREPARE_MODULES`
- present `modules/den` and `modules/fold` notes/hooks

## Validation

- `AGENT_PREPARE_MODULES='den fold' mise run agent:smoke -- --home /Users/rikonor/agents/c0da/home`
- `bash -n .mise/tasks/agent/smoke test/agent_smoke.bats`
- `mise run test agent_smoke`
- `git diff --check`
- `git pre-push`