### PR TITLE
ci: let sessions own hosted Pi

### DIFF
--- a/.mise/tasks/ci/env
+++ b/.mise/tasks/ci/env
@@ -70,14 +70,6 @@ trust_shiv_package_configs() {
   done < <(find "$HOME/.local/share/mise/installs" -path '*/packages/*/mise.toml' -print0 2>/dev/null)
 }
 
-install_pi() {
-  log "installing pi harness"
-  (
-    cd "$AGENT_HOME"
-    "$MISE_BIN" use -g github:KnickKnackLabs/pi@v0.80.3-kkl.1
-  )
-}
-
 setup_gpg() {
   log "setting up GPG"
   (
@@ -136,7 +128,6 @@ resolve_agent_github_login
 clone_home_repo
 install_home_tools
 trust_shiv_package_configs
-install_pi
 setup_gpg
 setup_email
 prepare_home_repo

--- a/test/hosted_agent.bats
+++ b/test/hosted_agent.bats
@@ -1,0 +1,21 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "hosted agent workflow delegates headless execution through sessions" {
+  workflow="$REPO_DIR/.github/workflows/agent-run.yml"
+  agent_task="$REPO_DIR/.mise/tasks/agent/_default"
+
+  grep -Fq 'mise run ci:env' "$workflow"
+  grep -Fq 'mise agent' "$workflow"
+  grep -Fq 'cmd=(shimmer agent --headless' "$agent_task"
+  grep -Eq '^"shiv:sessions"[[:space:]]*=' "$REPO_DIR/mise.toml"
+}
+
+@test "hosted agent setup does not install Pi directly" {
+  workflow="$REPO_DIR/.github/workflows/agent-run.yml"
+  ci_env="$REPO_DIR/.mise/tasks/ci/env"
+
+  ! grep -En 'github:[^[:space:]]+/(pi|pi-mono)@|install_pi' \
+    "$workflow" "$ci_env"
+}

--- a/test/hosted_agent.bats
+++ b/test/hosted_agent.bats
@@ -12,10 +12,15 @@ load test_helper
   grep -Eq '^"shiv:sessions"[[:space:]]*=' "$REPO_DIR/mise.toml"
 }
 
-@test "hosted agent setup does not install Pi directly" {
+@test "fold does not provision the sessions-owned Pi runtime" {
   workflow="$REPO_DIR/.github/workflows/agent-run.yml"
   ci_env="$REPO_DIR/.mise/tasks/ci/env"
+  direct_pi_backend='github:[[:alnum:]_.-]+/(pi|pi-mono)(@[[:alnum:]_.-]+)?'
 
-  ! grep -En 'github:[^[:space:]]+/(pi|pi-mono)@|install_pi' \
-    "$workflow" "$ci_env"
+  # Fold owns hosted bootstrap; sessions owns Pi selection and execution.
+  # Installing Pi here would create a second, potentially conflicting owner.
+  grep -Eq "$direct_pi_backend" <<< 'github:example/pi'
+  grep -Eq "$direct_pi_backend" <<< 'github:example/pi-mono@v1.2.3'
+  ! grep -En "$direct_pi_backend" \
+    "$workflow" "$ci_env" "$REPO_DIR/mise.toml"
 }


### PR DESCRIPTION
## Summary

- remove fold `ci:env`'s stale direct install of `github:KnickKnackLabs/pi@v0.80.3-kkl.1`
- keep the generated hosted workflow unchanged and let its existing `mise agent` path delegate through Shimmer to sessions
- add a fold regression that guards the hosted delegation chain and rejects direct Pi installs in the hosted workflow/setup surface

## Why

Fold pins `shiv:sessions = "0.4"`, currently resolved to sessions `0.4.11`. Sessions owns `github:KnickKnackLabs/pi@v0.80.6-kkl.1` in its own mise environment and invokes Pi through that environment. Installing an older ambient Pi in fold's hosted setup is redundant and leaves ownership split across layers.

The current path remains:

`agent-run.yml` → `ci:env` → `mise agent` → `shimmer agent --headless` → sessions wake/run → sessions-owned Pi

## Validation

- test-first regression failed on the old `install_pi` function, invocation, and `v0.80.3-kkl.1` pin
- `mise run test hosted_agent`: 2/2 passed, plus configured lints and welcome smoke
- `mise run test`: 145/145 passed, plus configured lints and welcome smoke
- `bash -n .mise/tasks/ci/env`
- `git diff --check`
- audit dependency checks:
  - Shimmer agent tests: 39/39 passed with one expected skip
  - sessions `run`, `wake`, and `harness_dispatch`: 98/98 passed
  - sessions Pi command tests: 16/16 passed

## Scope boundary

This PR does not edit generated workflows or agent homes. A current remote census shows all 12 home-generated workflows are already pin-free and use the modern split hooks; all 12 independent source copies of `.mise/tasks/ci/env` still contain the stale direct install. Those source tasks remain a separate review-before-mutation campaign.

Pi's move upstream to `earendil-works/pi` is also separate. The sessions-owned runtime should choose its approved source/version without reintroducing ambient fold or home pins.
