### PR TITLE
fix: fail closed in campaign promotion

### DIFF
--- a/.mise/tasks/homes/campaign/merge
+++ b/.mise/tasks/homes/campaign/merge
@@ -38,15 +38,26 @@ merge_one() {
     return 1
   fi
 
-  token=$(campaign_get_auth_token "$auth")
+  if ! token=$(campaign_get_auth_token "$auth"); then
+    return 1
+  fi
   target_ref="refs/remotes/origin/$TARGET_BRANCH"
   source_ref="$source_branch"
 
-  campaign_run_git "$token" -C "$clone" fetch origin \
-    "+refs/heads/$TARGET_BRANCH:$target_ref" >/dev/null
+  if ! campaign_run_git "$token" -C "$clone" fetch origin \
+    "+refs/heads/$TARGET_BRANCH:$target_ref" >/dev/null; then
+    printf 'ERROR: could not fetch %s %s\n' "$repo" "$TARGET_BRANCH" >&2
+    return 1
+  fi
 
-  target_sha=$(git -C "$clone" rev-parse --short=12 "$target_ref")
-  source_sha=$(git -C "$clone" rev-parse --short=12 "$source_ref")
+  if ! target_sha=$(git -C "$clone" rev-parse --short=12 "$target_ref"); then
+    printf 'ERROR: could not resolve %s %s\n' "$repo" "$target_ref" >&2
+    return 1
+  fi
+  if ! source_sha=$(git -C "$clone" rev-parse --short=12 "$source_ref"); then
+    printf 'ERROR: could not resolve %s %s\n' "$repo" "$source_ref" >&2
+    return 1
+  fi
 
   if ! git -C "$clone" merge-base --is-ancestor "$target_ref" "$source_ref"; then
     printf 'DIV %-28s %s %s is not ancestor of %s %s\n' \
@@ -64,7 +75,11 @@ merge_one() {
     return 0
   fi
 
-  campaign_run_git "$token" -C "$clone" push origin "$source_ref:refs/heads/$TARGET_BRANCH" >/dev/null
+  if ! campaign_run_git "$token" -C "$clone" push origin \
+    "$source_ref:refs/heads/$TARGET_BRANCH" >/dev/null; then
+    printf 'ERROR: could not push %s %s\n' "$repo" "$TARGET_BRANCH" >&2
+    return 1
+  fi
   printf 'MER %-28s %s %s -> %s\n' "$repo" "$TARGET_BRANCH" "$target_sha" "$source_sha"
 }
 

--- a/test/homes_campaign_merge.bats
+++ b/test/homes_campaign_merge.bats
@@ -50,6 +50,16 @@ setup() {
   mkdir -p "$STATE_DIR/clones"
   export STATE_DIR
 
+  MOCK_SECRETS="$TEST_TMPDIR/secrets"
+  cat > "$MOCK_SECRETS" <<'BASH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'missing secret: %s\n' "${2:-}" >&2
+exit 1
+BASH
+  chmod +x "$MOCK_SECRETS"
+  export SECRETS="$MOCK_SECRETS"
+
   ONE=$(make_repo one)
   TWO=$(make_repo two)
   DIVERGED=$(make_diverged_repo diverged)
@@ -60,6 +70,8 @@ repo	auth	clone	branch	base
 owner/one	-	$ONE	campaign/test	main
 owner/two	-	$TWO	campaign/test	main
 owner/diverged	-	$DIVERGED	campaign/test	main
+owner/auth-fail	missing	$ONE	campaign/test	main
+owner/fetch-fail	-	$TWO	campaign/test	main
 TSV
 }
 
@@ -115,6 +127,57 @@ teardown() {
   [ "$status" -ne 0 ]
   [[ "$output" == *"DIV owner/diverged"* ]]
   [[ "$output" == *"DRY owner/two"* ]]
+}
+
+@test "homes:campaign:merge fails closed on auth errors and keeps going" {
+  run fold_task homes:campaign:merge \
+    --work-dir "$STATE_DIR" \
+    --repo owner/auth-fail \
+    --repo owner/two \
+    --keep-going \
+    --dry-run
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"could not read missing/github-pat"* ]]
+  [[ "$output" != *"OK  owner/auth-fail"* ]]
+  [[ "$output" != *"DRY owner/auth-fail"* ]]
+  [[ "$output" != *"MER owner/auth-fail"* ]]
+  [[ "$output" == *"DRY owner/two"* ]]
+}
+
+@test "homes:campaign:merge fails closed on fetch errors and keeps going" {
+  rm -rf "$TEST_TMPDIR/two.git"
+
+  run fold_task homes:campaign:merge \
+    --work-dir "$STATE_DIR" \
+    --repo owner/fetch-fail \
+    --repo owner/one \
+    --keep-going \
+    --dry-run
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"ERROR: could not fetch owner/fetch-fail main"* ]]
+  [[ "$output" != *"OK  owner/fetch-fail"* ]]
+  [[ "$output" != *"DRY owner/fetch-fail"* ]]
+  [[ "$output" != *"MER owner/fetch-fail"* ]]
+  [[ "$output" == *"DRY owner/one"* ]]
+}
+
+@test "homes:campaign:merge fails closed when the remote rejects a push" {
+  cat > "$TEST_TMPDIR/two.git/hooks/pre-receive" <<'BASH'
+#!/usr/bin/env bash
+echo "push rejected intentionally" >&2
+exit 1
+BASH
+  chmod +x "$TEST_TMPDIR/two.git/hooks/pre-receive"
+
+  run fold_task homes:campaign:merge \
+    --work-dir "$STATE_DIR" \
+    --repo owner/two
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"ERROR: could not push owner/two main"* ]]
+  [[ "$output" != *"MER owner/two"* ]]
 }
 
 @test "homes:campaign:merge fails before init" {


### PR DESCRIPTION
## Summary

- fail immediately when campaign auth, fetch, ref resolution, or push fails
- prevent stale remote-tracking refs from producing false `OK`, `DRY`, or `MER` outcomes
- preserve `--keep-going` across failed targets while returning nonzero overall
- add regression coverage for auth failure, fetch failure, and rejected push

## Root cause

`merge_one` is invoked under `if ! merge_one ...`. Bash disables `errexit` behavior for commands inside a function used as a conditional, so bare failing commands inside `merge_one` continued. During the Pi-pin campaign, unavailable secret approval caused token lookup and fetch to fail, but the task compared stale `origin/main` and printed `OK`.

The fix uses explicit guarded returns at every promotion boundary rather than relying on `set -e`.

## Validation

- test-first auth and fetch regressions failed because the command exited zero
- test-first rejected-push regression failed because the command exited zero
- `mise run test homes_campaign_merge`: 8/8 passed plus configured lint/welcome smoke
- `mise run test`: 148/148 passed plus configured lint/welcome smoke
- `bash -n .mise/tasks/homes/campaign/merge`
- `git diff --check`
- `mise run git:pre-commit`: passed
- `mise run git:pre-push`: no failures; warnings were the new branch lacking an upstream before push and an existing GitHub merge commit reported as non-good by local GPG verification

Closes #146.
