### PR TITLE
Cache ordinary CI tool setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,23 +12,30 @@ jobs:
   test:
     runs-on: ubuntu-latest
     env:
+      # Share the exact workflow-host tool boundary with hosted agent wakes.
+      MISE_DATA_DIR: /home/runner/.local/share/mise
       MISE_EXPERIMENTAL: "1"
       GITHUB_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Resolve mise cache epoch
+        id: mise-cache-epoch
+        run: echo "value=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+
       - name: Set up mise
         uses: jdx/mise-action@v4
         with:
-          install: false
-
-      - name: Install tools
+          install: true
+          cache: true
+          # Share the repository-scoped daily cache with hosted agent wakes.
+          cache_key: agent-mise-v2-${{ steps.mise-cache-epoch.outputs.value }}-{{platform}}-{{file_hash}}
         env:
           MISE_JOBS: 1
-        run: |
-          mise trust
-          mise install
+          # Keep pipx interpreters inside mise-action's cache boundary.
+          UV_PYTHON_INSTALL_DIR: /home/runner/.local/share/mise/uv-python
+          UV_MANAGED_PYTHON: "1"
 
       - name: Run tests
         run: mise run test


### PR DESCRIPTION
## Summary

- reuse Fold's proven repository-scoped daily mise cache in ordinary test CI
- share the exact cache key, data directory, serialized install boundary, and pipx interpreter path with hosted agent wakes
- remove the duplicate uncached `mise trust && mise install` step

## Baseline

Recent unchanged ordinary CI runs spent more time installing tools than testing:

| Run | Install tools | Tests |
|---|---:|---:|
| `29543756480` | 117s | 36s |
| `29544064620` | 77s | 41s |

The agent-wake path has already proved the same Fold tool cache: a matched production warm restore reduced workflow-host setup from 89s to 9s.

## Design

Ordinary CI and hosted agent wakes now use the same daily key:

```text
agent-mise-v2-<UTC date>-<platform>-<mise config hash>
```

The first compatible Fold job each UTC day fills the repository cache. Later ordinary tests and agent wakes share it. The date bounds fuzzy `shiv:*` and plugin freshness to one day. Step-local environment keeps cache-construction settings out of the test process.

## Hosted proof

Exact-head run `29545104205` provides a matched cold/warm comparison:

| Attempt | Cache | Mise setup | Tests | Whole job |
|---|---|---:|---:|---:|
| 1 | miss + save | 91s | 38s | 2m13s |
| 2 | exact-key hit | 9s | 39s | 53s |

The warm restore downloaded the 652,721,696-byte archive at up to about 173 MB/s. Mise setup saved 82 seconds, or about 90%, while test duration remained stable. The key and cache version match the hosted-agent path.

Pull-request caches are scoped to the PR merge ref. After merge, the first main run creates the default-branch cache that both ordinary CI and agent wakes may restore.

## Validation

- pinned actionlint 1.7.7 with ShellCheck 0.11.0
- YAML parse with the macOS system Ruby
- `git diff --check`
- exact cache boundary compared with merged `agent-run.yml`
- matched hosted cold/warm run with all 155 BATS tests green
