### PR TITLE
Run Fold BATS files in parallel

### DIFF
--- a/.mise/tasks/test
+++ b/.mise/tasks/test
@@ -1,14 +1,103 @@
 #!/usr/bin/env bash
 #MISE description="Run fold tests, lint, and welcome smoke"
-#USAGE arg "[args]" var=#true default="" help="Test files, suite names, BATS flags, or 'codebase'"
-#USAGE example "mise run test" header="Run all tests"
-#USAGE example "mise run test github_repo_invitations" header="Run one suite by bare name"
+#USAGE arg "[args]" var=#true default="" help="Test files, suite names, BATS flags, or 'bats'/'codebase'"
+#USAGE example "mise run test" header="Run all tests and gates"
+#USAGE example "mise run test bats github_repo_invitations" header="Run one BATS suite without other gates"
 #USAGE example "mise run test codebase" header="Run only codebase lint"
 #USAGE example "mise run test --filter accept" header="Filter tests by name"
+#USAGE example "mise run test --jobs 1" header="Run serially for debugging"
 set -euo pipefail
 
 TEST_DIR="$MISE_CONFIG_ROOT/test"
+BATS_COMMAND="${BATS_COMMAND:-}"
+RUSH_COMMAND="${RUSH_COMMAND:-rush}"
 CODEBASE_BIN="${CODEBASE_BIN:-codebase}"
+DEFAULT_PARALLEL_JOBS=4
+
+command_available() {
+  case "$1" in
+    */*) [ -x "$1" ] ;;
+    *) command -v "$1" >/dev/null 2>&1 ;;
+  esac
+}
+
+run_bats_suite() {
+  local cli_jobs=""
+  local cli_parallel_binary=""
+  local has_within_file_override=false
+  local index arg next
+
+  for ((index = 0; index < ${#bats_args[@]}; index++)); do
+    arg="${bats_args[$index]}"
+    case "$arg" in
+      -j|--jobs)
+        next=$((index + 1))
+        cli_jobs="${bats_args[$next]-}"
+        ;;
+      --parallel-binary-name)
+        next=$((index + 1))
+        cli_parallel_binary="${bats_args[$next]-}"
+        ;;
+      --no-parallelize-within-files)
+        has_within_file_override=true
+        ;;
+    esac
+  done
+
+  local effective_jobs
+  if [ -n "$cli_jobs" ]; then
+    effective_jobs="$cli_jobs"
+  elif [ -n "${BATS_NUMBER_OF_PARALLEL_JOBS:-}" ]; then
+    effective_jobs="$BATS_NUMBER_OF_PARALLEL_JOBS"
+  else
+    effective_jobs="$DEFAULT_PARALLEL_JOBS"
+    export BATS_NUMBER_OF_PARALLEL_JOBS="$effective_jobs"
+  fi
+
+  if ! [[ "$effective_jobs" =~ ^[1-9][0-9]*$ ]]; then
+    echo "Error: BATS parallel jobs must be a positive integer, got '$effective_jobs'." >&2
+    return 2
+  fi
+
+  local effective_parallel_binary
+  if [ -n "$cli_parallel_binary" ]; then
+    effective_parallel_binary="$cli_parallel_binary"
+  elif [ -n "${BATS_PARALLEL_BINARY_NAME:-}" ]; then
+    effective_parallel_binary="$BATS_PARALLEL_BINARY_NAME"
+  else
+    effective_parallel_binary="$RUSH_COMMAND"
+    export BATS_PARALLEL_BINARY_NAME="$effective_parallel_binary"
+  fi
+
+  local effective_bats_command="${BATS_COMMAND:-bats}"
+  if ! command_available "$effective_bats_command"; then
+    echo "Error: BATS executable '$effective_bats_command' is unavailable; run 'mise install'." >&2
+    return 127
+  fi
+
+  local command_args=()
+  if [ "$effective_jobs" -gt 1 ]; then
+    if ! command_available "$effective_parallel_binary"; then
+      echo "Error: BATS parallel runner '$effective_parallel_binary' is unavailable for $effective_jobs jobs; run 'mise install' or use --jobs 1." >&2
+      return 127
+    fi
+    if ! $has_within_file_override; then
+      # BATS 1.13 polls its within-file semaphore once per second. Keep each file
+      # serial and let Rush schedule independent files without that delay.
+      command_args+=(--no-parallelize-within-files)
+    fi
+    printf 'BATS parallelism: %s jobs across files via %s\n' "$effective_jobs" "$effective_parallel_binary"
+  else
+    printf 'BATS parallelism: serial\n'
+  fi
+
+  command_args+=("${bats_args[@]}")
+  if [ -n "$BATS_COMMAND" ]; then
+    "$BATS_COMMAND" "${command_args[@]}"
+  else
+    bats "${command_args[@]}"
+  fi
+}
 
 args=()
 if [ -n "${usage_args:-}" ]; then
@@ -21,8 +110,13 @@ fi
 run_bats=false
 run_codebase=false
 run_welcome=false
+bats_only=false
 bats_args=()
 has_target=false
+
+for arg in ${args[@]+"${args[@]}"}; do
+  [ "$arg" != "bats" ] || bats_only=true
+done
 
 if [ "${#args[@]}" -eq 0 ]; then
   run_bats=true
@@ -30,14 +124,20 @@ if [ "${#args[@]}" -eq 0 ]; then
   run_welcome=true
 else
   for arg in ${args[@]+"${args[@]}"}; do
+    if [ "$arg" = "bats" ]; then
+      run_bats=true
+      continue
+    fi
     if [ "$arg" = "codebase" ]; then
       run_codebase=true
       continue
     fi
 
     run_bats=true
-    run_codebase=true
-    run_welcome=true
+    if ! $bats_only; then
+      run_codebase=true
+      run_welcome=true
+    fi
     if [[ "$arg" != -* && "$arg" != *.bats && -f "$TEST_DIR/$arg.bats" ]]; then
       bats_args+=("$TEST_DIR/$arg.bats")
       has_target=true
@@ -54,7 +154,7 @@ if [ "$run_bats" = "true" ]; then
   fi
 
   printf '\n== bats ==\n'
-  bats "${bats_args[@]}"
+  run_bats_suite
 fi
 
 if [ "$run_codebase" = "true" ]; then

--- a/mise.toml
+++ b/mise.toml
@@ -10,6 +10,7 @@ header = '''printf '\n== %s ==\n''''
 shiv = "https://github.com/KnickKnackLabs/vfox-shiv"
 
 [tools]
+"aqua:shenwei356/rush" = "0.9.0" # Cross-file BATS parallel runner
 usage = "3.2.1"                   # CLI arg parsing for tasks
 yq = "4.50.1"                     # YAML processing
 jq = "1.8.1"                     # JSON processing for task composition

--- a/test/test-task.bats
+++ b/test/test-task.bats
@@ -10,6 +10,43 @@ setup() {
   export TMPBIN
 }
 
+setup_bats_mocks() {
+  BATS_LOG="$BATS_TEST_TMPDIR/bats.log"
+  export BATS_LOG
+
+  cat > "$TMPBIN/bats" <<'BASH'
+#!/usr/bin/env bash
+set -euo pipefail
+{
+  printf 'jobs=%s\n' "${BATS_NUMBER_OF_PARALLEL_JOBS:-}"
+  printf 'runner=%s\n' "${BATS_PARALLEL_BINARY_NAME:-}"
+  for arg in "$@"; do
+    printf 'arg=%s\n' "$arg"
+  done
+} > "$BATS_LOG"
+BASH
+
+  cat > "$TMPBIN/rush" <<'BASH'
+#!/usr/bin/env bash
+exit 0
+BASH
+
+  chmod +x "$TMPBIN/bats" "$TMPBIN/rush"
+  export BATS_COMMAND="$TMPBIN/bats"
+  export RUSH_COMMAND="$TMPBIN/rush"
+  unset BATS_NUMBER_OF_PARALLEL_JOBS BATS_PARALLEL_BINARY_NAME
+}
+
+log_value() {
+  local key="$1"
+  awk -F= -v key="$key" '$1 == key { print substr($0, length(key) + 2); exit }' "$BATS_LOG"
+}
+
+arg_count() {
+  local expected="$1"
+  awk -F= -v expected="$expected" '$1 == "arg" && substr($0, 5) == expected { count++ } END { print count + 0 }' "$BATS_LOG"
+}
+
 @test "test codebase runs configured codebase lints" {
   cat > "$TMPBIN/codebase" <<'EOF'
 #!/usr/bin/env bash
@@ -23,4 +60,95 @@ EOF
 
   [ "$status" -eq 0 ]
   grep -q "^lint$" "$BATS_TEST_TMPDIR/codebase-args"
+}
+
+@test "test bats defaults to four Rush jobs across files" {
+  setup_bats_mocks
+
+  run fold_task test bats agent_list --filter json
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"4 jobs across files"* ]]
+  [[ "$output" != *"codebase lint"* ]]
+  [[ "$output" != *"welcome smoke"* ]]
+  [ "$(log_value jobs)" = "4" ]
+  [ "$(log_value runner)" = "$TMPBIN/rush" ]
+  [ "$(arg_count --no-parallelize-within-files)" -eq 1 ]
+  [ "$(arg_count "$REPO_DIR/test/agent_list.bats")" -eq 1 ]
+  [ "$(arg_count --filter)" -eq 1 ]
+  [ "$(arg_count json)" -eq 1 ]
+}
+
+@test "explicit BATS jobs override is forwarded once" {
+  setup_bats_mocks
+
+  run fold_task test bats --jobs 3 agent_list
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"3 jobs across files"* ]]
+  [ "$(log_value jobs)" = "" ]
+  [ "$(arg_count --jobs)" -eq 1 ]
+  [ "$(arg_count 3)" -eq 1 ]
+  [ "$(arg_count --no-parallelize-within-files)" -eq 1 ]
+}
+
+@test "BATS environment jobs override the default" {
+  setup_bats_mocks
+  export BATS_NUMBER_OF_PARALLEL_JOBS=2
+
+  run fold_task test bats agent_list
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"2 jobs across files"* ]]
+  [ "$(log_value jobs)" = "2" ]
+  [ "$(arg_count --jobs)" -eq 0 ]
+}
+
+@test "BATS environment serial opt-out does not require Rush" {
+  setup_bats_mocks
+  export BATS_NUMBER_OF_PARALLEL_JOBS=1
+  export RUSH_COMMAND="$TMPBIN/missing-rush"
+
+  run fold_task test bats agent_list
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"BATS parallelism: serial"* ]]
+  [ "$(arg_count --no-parallelize-within-files)" -eq 0 ]
+}
+
+@test "BATS CLI serial opt-out does not require Rush" {
+  setup_bats_mocks
+  export RUSH_COMMAND="$TMPBIN/missing-rush"
+
+  run fold_task test bats --jobs 1 agent_list
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"BATS parallelism: serial"* ]]
+  [ "$(arg_count --no-parallelize-within-files)" -eq 0 ]
+}
+
+@test "parallel BATS fails clearly when Rush is unavailable" {
+  setup_bats_mocks
+  export RUSH_COMMAND="$TMPBIN/missing-rush"
+
+  run -127 fold_task test bats agent_list
+  [ "$status" -eq 127 ]
+  [[ "$output" == *"parallel runner '$TMPBIN/missing-rush' is unavailable for 4 jobs"* ]]
+  [[ "$output" == *"run 'mise install' or use --jobs 1"* ]]
+  [ ! -e "$BATS_LOG" ]
+}
+
+@test "explicit BATS runner override is preserved" {
+  setup_bats_mocks
+  cp "$TMPBIN/rush" "$TMPBIN/alternate-runner"
+  export BATS_PARALLEL_BINARY_NAME="$TMPBIN/alternate-runner"
+
+  run fold_task test bats agent_list
+  [ "$status" -eq 0 ]
+  [ "$(log_value runner)" = "$TMPBIN/alternate-runner" ]
+}
+
+@test "invalid BATS job override fails before execution" {
+  setup_bats_mocks
+  export BATS_NUMBER_OF_PARALLEL_JOBS=lots
+
+  run fold_task test bats agent_list
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"must be a positive integer"* ]]
+  [ ! -e "$BATS_LOG" ]
 }


### PR DESCRIPTION
## Summary

- declare Rush 0.9.0 and run separate Fold `.bats` files with the measured four-job Template#8 default
- keep tests inside each file serial to avoid BATS 1.13's one-second within-file semaphore polling
- preserve CLI/environment job overrides, runner overrides, and both serial debugging forms
- add a BATS-only selector plus task-contract coverage for precedence and failure behavior

## Why

Fold has 23 separate BATS files but previously ran all 155 cases serially. The final pre-change full gate observed during Fold#164 refresh took 239.726 seconds.

A state-isolation audit found mutable fixtures under per-test `BATS_TEST_TMPDIR` or unique `mktemp` directories; real-repo references are read-only or symlink targets. The first full four-job cross-file gate passed 157/157 tests and all existing gates in 145.38 seconds. That is about 94 seconds / 39% faster while adding eight task-contract tests.

The task intentionally passes `--no-parallelize-within-files`. Template#7 records the upstream BATS semaphore problem; Template#8 contains the independently measured canonical contract.

## Behavior

- precedence: caller `--jobs`, then `BATS_NUMBER_OF_PARALLEL_JOBS`, then four jobs
- default runner: declared Rush; explicit runner overrides remain
- `mise run test --jobs 1` and `BATS_NUMBER_OF_PARALLEL_JOBS=1 mise run test` remain serial
- Rush is required only when effective jobs exceed one
- `mise run test bats [suite/flags]` runs BATS without repeating codebase/welcome gates during focused iteration
- ordinary `mise run test` still runs BATS, configured codebase lint, and welcome smoke

## Hosted cold/warm proof

Exact-head run `29586916612` attempt 1 correctly missed after Rush changed the sole matched cache input, root `mise.toml`. It spent 2m36s installing/saving the new 622 MiB cache, then completed the parallel test gate in 20s.

Attempt 2 hit exact key `agent-mise-v2-2026-07-17-linux-x64-ubuntu24-1f9a434da1069bb3b9a067f410b7ef6b7b2b59e27ef9cad97164a5843d363245`: setup restored in 7s, tests/gates took 20s, and the full job completed in 31s.

## Validation

- focused parallel task contract: 9/9 BATS
- full four-job gate: 157/157 BATS, configured codebase lints, welcome smoke
- Bash syntax and pinned ShellCheck 0.11.0
- `git diff --check`
- managed notes clean
- signed commit verified

No serial rerun was performed after the measured four-minute baseline. No within-file parallelism, Template merge, or downstream rollout is included.
