### PR TITLE
fix: observe Pi after desk wake deadline

### DIFF
--- a/.mise/tasks/agent/desk/wake
+++ b/.mise/tasks/agent/desk/wake
@@ -7,7 +7,7 @@
 #USAGE flag "--model <model>" default="" help="Provider/model passed explicitly to shimmer agent"
 #USAGE flag "--title <title>" default="agent desk wake — root handoff" help="Title line prepended to the packet"
 #USAGE flag "--identity-source <path>" default="" help="Directory where 'shimmer as <agent>' runs (default: resolved desk home)"
-#USAGE flag "--startup-timeout <seconds>" default="30" help="Seconds to wait for a new live Pi process in the desk home"
+#USAGE flag "--startup-timeout <seconds>" default="30" help="Seconds to wait before one final Pi readiness observation"
 #USAGE flag "--work-dir <path>" default="" help="Directory for generated launcher (default: temporary directory)"
 #USAGE flag "-y --yes" default=#false help="Actually call shell run; without this, render and print the plan only"
 #USAGE arg "<agent>" help="Agent identity to launch"
@@ -107,7 +107,7 @@ printf 'shell:           %s\n' "$SHELL_NAME"
 printf 'packet:          %s\n' "$PACKET_PATH"
 printf 'model:           %s\n' "$MODEL"
 printf 'identity-source: %s\n' "$IDENTITY_SOURCE"
-printf 'startup timeout: %ss\n' "$STARTUP_TIMEOUT"
+printf 'startup window:  %ss plus one final observation\n' "$STARTUP_TIMEOUT"
 printf 'launcher:        %s\n' "$LAUNCHER"
 
 if [ "$YES" != "true" ]; then
@@ -139,9 +139,13 @@ printf '%s\n' "$session_processes" |
 printf '\nlaunching shell %s from %s\n' "$SHELL_NAME" "$HOME_PATH"
 "$AGENT_DESK_SHELL_BIN" run --cwd "$HOME_PATH" "$SHELL_NAME" "$LAUNCHER"
 
-printf '\nwaiting up to %ss for a new live Pi process\n' "$STARTUP_TIMEOUT"
+printf '\nwaiting %ss plus one final observation for a new live Pi process\n' "$STARTUP_TIMEOUT"
 started_at=$SECONDS
-while [ $((SECONDS - started_at)) -lt "$STARTUP_TIMEOUT" ]; do
+while :; do
+  final_observation=false
+  if [ $((SECONDS - started_at)) -ge "$STARTUP_TIMEOUT" ]; then
+    final_observation=true
+  fi
   if ! agent_desk_shell_status "$SHELL_NAME" >/dev/null 2>&1; then
     echo "ERROR: agent shell exited before Pi became ready" >&2
     if ! mise run -q agent:desk:smoke --shell "$SHELL_NAME"; then
@@ -178,10 +182,15 @@ while [ $((SECONDS - started_at)) -lt "$STARTUP_TIMEOUT" ]; do
     exit 0
   fi
 
-  sleep 1
+  if [ "$final_observation" = true ]; then
+    break
+  fi
+  if [ $((SECONDS - started_at)) -lt "$STARTUP_TIMEOUT" ]; then
+    sleep 1
+  fi
 done
 
-echo "ERROR: no new live Pi process appeared within ${STARTUP_TIMEOUT}s" >&2
+echo "ERROR: no new live Pi process appeared during the ${STARTUP_TIMEOUT}s window or final observation" >&2
 if ! mise run -q agent:desk:smoke --shell "$SHELL_NAME"; then
   : # Preserve the primary startup timeout if diagnostics also fail.
 fi

--- a/test/agent_desk.bats
+++ b/test/agent_desk.bats
@@ -12,6 +12,8 @@ setup() {
   export SHELL_RUN_MARKER="$BATS_TEST_TMPDIR/shell-ran"
   export SHELL_EXITED_MARKER="$BATS_TEST_TMPDIR/shell-exited"
   export SESSIONS_LOG="$BATS_TEST_TMPDIR/sessions.log"
+  export SESSIONS_CALLS="$BATS_TEST_TMPDIR/sessions-calls"
+  printf '0\n' > "$SESSIONS_CALLS"
   export FAKE_SESSIONS_MODE="ready"
   write_fake_shell
   write_fake_sessions
@@ -59,6 +61,8 @@ write_fake_sessions() {
 #!/usr/bin/env bash
 set -euo pipefail
 printf 'sessions %s\n' "$*" >> "${SESSIONS_LOG:?}"
+call_count=$(($(cat "${SESSIONS_CALLS:?}") + 1))
+printf '%s\n' "$call_count" > "$SESSIONS_CALLS"
 if [ "${1:-}" != ps ] || [ "${2:-}" != --all ] || [ "${3:-}" != --json ]; then
   echo "unexpected sessions command: $*" >&2
   exit 2
@@ -71,9 +75,20 @@ if [ "${FAKE_SESSIONS_MODE:-ready}" = fail ]; then
   echo "sessions failed intentionally" >&2
   exit 42
 fi
+mode="${FAKE_SESSIONS_MODE:-ready}"
+if [ "$mode" = deadline-edge ] && [ "$call_count" -eq 2 ]; then
+  sleep "${FAKE_SESSIONS_DELAY:-1.1}"
+fi
+session_ready=false
+if [ -f "${SHELL_RUN_MARKER:?}" ]; then
+  case "$mode" in
+    ready) session_ready=true ;;
+    deadline-edge) [ "$call_count" -ge 3 ] && session_ready=true ;;
+  esac
+fi
 if [ -z "${FAKE_SESSION_CWD:-}" ]; then
   printf '[]\n'
-elif [ "${FAKE_SESSIONS_MODE:-ready}" = ready ] && [ -f "${SHELL_RUN_MARKER:?}" ]; then
+elif [ "$session_ready" = true ]; then
   jq -n --arg cwd "$FAKE_SESSION_CWD" \
     '[{session_id:"old-pi-session",status:"live",cwd:$cwd,harness:"pi"},{session_id:"new-pi-session",status:"live",cwd:$cwd,harness:"pi"}]'
 else
@@ -471,6 +486,24 @@ SH
   grep -q "sessions ps --all --json" "$SESSIONS_LOG"
 }
 
+@test "agent:desk:wake makes a final observation after a slow deadline-edge probe" {
+  home="$BATS_TEST_TMPDIR/home"
+  work_dir="$BATS_TEST_TMPDIR/wake"
+  packet="$BATS_TEST_TMPDIR/packet.md"
+  make_repo "$home" home
+  printf 'hello packet\n' > "$packet"
+  export FAKE_SESSION_CWD="$(cd "$home" && pwd -P)"
+  export FAKE_SESSIONS_MODE=deadline-edge
+  export FAKE_SESSIONS_DELAY=1.1
+
+  run fold_task agent:desk:wake quick --home "$home" --shell quick-a --packet "$packet" --model openai-codex/gpt-5.6-sol --startup-timeout 1 --work-dir "$work_dir" --yes
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Agent runtime ready"* ]]
+  [[ "$output" == *"session: new-pi-session"* ]]
+  [ "$(cat "$SESSIONS_CALLS")" -ge 3 ]
+}
+
 @test "agent:desk:wake rejects a running shell without a new Pi process" {
   home="$BATS_TEST_TMPDIR/home"
   work_dir="$BATS_TEST_TMPDIR/wake"
@@ -483,7 +516,7 @@ SH
   run fold_task agent:desk:wake quick --home "$home" --shell quick-a --packet "$packet" --model openai-codex/gpt-5.6-sol --startup-timeout 1 --work-dir "$work_dir" --yes
 
   [ "$status" -ne 0 ]
-  [[ "$output" == *"no new live Pi process appeared within 1s"* ]]
+  [[ "$output" == *"no new live Pi process appeared during the 1s window or final observation"* ]]
   [[ "$output" == *"line one"* ]]
 }
 


### PR DESCRIPTION
## Summary

- make the desk-wake readiness window end with one process observation that begins at or after the configured deadline
- avoid a false timeout when a slow `sessions ps` poll snapshots just before Pi appears and returns near the deadline
- state the final-observation semantics in the CLI output and preserve focused timeout diagnostics

## Real failure reproduced

The first fresh Ikma wake through Fold#176 created and woke Sessions ID `f19d41f5-a51b-469b-84fc-c943c7cb0893`. Pi became live in the correct desk home about 25 seconds after launch, but one `sessions ps --all --json` observation takes about 4.15 seconds on this machine. A poll that began before Pi appeared returned near the 30-second boundary, and the old precondition ended the loop without a final observation. The task returned a false timeout while Ikma was already live.

This change always begins one final observation at or after the deadline. It still fails when that observation finds no new exact-home Pi process.

## Validation

- `mise run test agent_desk`: 15/15 BATS, configured codebase lints, and welcome smoke passed
- final focused `mise exec -- bats test/agent_desk.bats`: 15/15 passed
- regression delays the first post-launch observation across a one-second deadline, then exposes Pi only to the required final observation
- `bash -n .mise/tasks/agent/desk/wake`
- `git diff --check`

No peer was re-woken by this patch. The already-live Ikma session continues independently in its fresh desk.
