### PR TITLE
deps: adopt Notes 0.9 and Codebase 0.4

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -22,16 +22,17 @@ gum = "0.17.0"                   # Human-readable task tables and welcome output
 "shiv:websites" = "0.1"
 "shiv:sessions" = "0.4"
 "shiv:modules" = "0.9"
-"shiv:notes" = "0.8"
+"shiv:notes" = "0.9"
 "shiv:threads" = "0.3"
 "shiv:rudi" = "0.5"                       # git-crypt wrapper — CI calls rudi install directly
 "shiv:secrets" = "0.2"
 "shiv:emails" = "0.7"
-"shiv:codebase" = "0.3"
+"shiv:codebase" = "0.4"
 "shiv:comments" = "0.3"
 "shiv:chat" = "0.2"
 
 [_.codebase]
+name = "fold"
 lint = ["mise-settings", "gum-table"]
 
 [_.codebase.scope]


### PR DESCRIPTION
## Summary

- track the released Notes 0.9 minor stream
- track the released Codebase 0.4 minor stream
- declare Fold's stable Codebase name

## Validation

- `mise install` selected Notes 0.9.0 and Codebase 0.4.0
- `mise run agent:prepare`
- `mise welcome --local`
- `codebase lint .`
- `mise run test` (175 BATS, configured lints, welcome smoke)
- Fold pre-commit and pre-push checks
