### PR TITLE
test: check home email mode portably

### DIFF
--- a/test/homes_email.bats
+++ b/test/homes_email.bats
@@ -110,7 +110,10 @@ SH
   [ "$status" -eq 0 ]
   [[ "$output" == *"Email ready: test-agent <test-agent@ricon.family>"* ]]
   [ "$(cat "$PASSWORD_CAPTURE")" = fixture-email-password ]
-  [ "$(stat -f '%Lp' "$HOME_REPO/.emails/himalaya.toml" 2>/dev/null || stat -c '%a' "$HOME_REPO/.emails/himalaya.toml")" = 600 ]
+  local config_mode
+  config_mode=$(stat -f '%Lp' "$HOME_REPO/.emails/himalaya.toml" 2>/dev/null) \
+    || config_mode=$(stat -c '%a' "$HOME_REPO/.emails/himalaya.toml")
+  [ "$config_mode" = 600 ]
   git -C "$HOME_REPO" check-ignore -q -- .emails/himalaya.toml
   [ -z "$(git -C "$HOME_REPO" status --short --untracked-files=all)" ]
   grep -Fx 'get test-agent/email-password' "$SECRET_LOG"


### PR DESCRIPTION
## Summary

- capture the BSD `stat` result before falling back to GNU `stat`
- prevent failed GNU filesystem-stat output from leaking into the asserted mode
- restore the Linux/macOS home-email setup test gate

## Context

Fold main and notes-only PR #188 both fail hosted Linux at the home-local email mode assertion. GNU `stat -f '%Lp'` can emit filesystem output before exiting unsuccessfully; placing both probes inside one command substitution preserves that unwanted output alongside the GNU fallback result.

The setup task already uses separate assignments and is correct. This PR makes the test use the same portable shape.

## Validation

- `mise run test homes_email` (4/4)
- `mise run test` (182 BATS tests, both Codebase lints, welcome smoke)
- `git diff --check`
- `mise run git:pre-commit`
- `mise run git:pre-push .`
- signed commit verified with Junior's GPG key
